### PR TITLE
CiWorkflow.yml Generalization Updates [Rebase & FF]

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -93,7 +93,7 @@ jobs:
         run: cargo make deny
 
       - name: Run cargo-clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo make clippy
         env:
           RUSTC_BOOTSTRAP: 1
 


### PR DESCRIPTION
**CiWorkflow.yml: Add additional workflow params**

Adds parameters to allow the workflow to be adapted to more Patina
repos.

- `build-tasks`: Comma-separated list of build tasks to run (e.g.,
  'build,build-x64,build-aarch64')
- `run-cargo-vet`: Whether to run cargo vet
- `run-release-dry-run`: Whether to run cargo release dry run

---

**CiWorkflow.yml: Standardize on `cargo make clippy`**

Call `cargo make clippy` allowing the cargo-make makefile to
configure clippy-specific params as needed.