### PR TITLE
Notebooks: Add GitHub Issue notebooks

### DIFF
--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -1,0 +1,62 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Patina GitHub PR Dashboard\r\n\r\nThis notebook displays [Patina](https://opendevicepartnership.github.io/patina/) pull request status."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of patina repos\r\n$repos=repo:OpenDevicePartnership/patina repo:OpenDevicePartnership/patina-dxe-core-qemu repo:OpenDevicePartnership/patina-qemu repo:OpenDevicePartnership/patina-mtrr repo:OpenDevicePartnership/patina-paging repo:OpenDevicePartnership/patina-devops repo:OpenDevicePartnership/patina-readiness-tool repo:OpenDevicePartnership/patina-fw-patcher repo:OpenDevicePartnership/patina-edk2 repo:OpenDevicePartnership/patina-lzma-rs repo:OpenDevicePartnership/uefi-corosensei"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 All Open Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues with no labels"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false no:label"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues with no assignee"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false no:assignee"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues with needs-owner label"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:needs-owner"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues marked stale"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:stale"
+  }
+]

--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -1,0 +1,52 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Patina GitHub PR Dashboard\r\n\r\nThis notebook displays [Patina](https://opendevicepartnership.github.io/patina/) pull request status."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of patina repos\r\n$repos=repo:OpenDevicePartnership/patina repo:OpenDevicePartnership/patina-dxe-core-qemu repo:OpenDevicePartnership/patina-qemu repo:OpenDevicePartnership/patina-mtrr repo:OpenDevicePartnership/patina-paging repo:OpenDevicePartnership/patina-devops repo:OpenDevicePartnership/patina-readiness-tool repo:OpenDevicePartnership/patina-fw-patcher repo:OpenDevicePartnership/patina-edk2 repo:OpenDevicePartnership/patina-lzma-rs repo:OpenDevicePartnership/uefi-corosensei"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 All Open PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 - 🤖 = Opened by Humans"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✅ All Approved PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr review:approved"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🏁 All Completed PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// This needs to be bumped very occassionally (annually likely) to prevent\r\n// the maximum allowed number of results from being reached.\r\n$since=2025-10-01\r\n\r\n$repos is:closed type:pr sort:created-desc closed:>$since"
+  }
+]


### PR DESCRIPTION
Can be rendered with the VS Code GitHub Issue Notebooks extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks) to show PRs and issues across all Patina repos in a single dashboard.

---

Examples:

<img width="1180" height="1125" alt="image" src="https://github.com/user-attachments/assets/57cd85e6-28b6-40c5-8938-a44f888ffe77" />

---

<img width="1434" height="1101" alt="image" src="https://github.com/user-attachments/assets/be059760-f029-4dce-8e55-79a571602281" />