### PR TITLE
Optmize CI Runtime

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -80,8 +80,6 @@ jobs:
   run:
     name: Rust CI
 
-    needs: [ basic_ci ]
-
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Moves some of the CI tests that are operating system agnostic to the "Basic CI" job, and updates all three to run simultaneously.

This improves CI runtime from ~14-15 minutes down to ~10 minutes.

We are still mainly limited by windows CI test which is taking the full ~10 minutes compared to 3 minutes & 5 minutes for the other two jobs.