### PR TITLE
CrateVersionUpdater.yml: bugfix adding Cargo.toml

### DIFF
--- a/.github/workflows/CrateVersionUpdater.yml
+++ b/.github/workflows/CrateVersionUpdater.yml
@@ -91,7 +91,8 @@ jobs:
       
       - name: Push Changes
         run: |
-          git add Cargo.toml **/Cargo.toml
+          shopt -s globstar
+          git add **/Cargo.toml
           git commit -m "Chore: Update crate versions to ${{ steps.release_tag.outputs.tag }}"
           git push origin HEAD:github-actions/release-version-update --force
       


### PR DESCRIPTION
The logic to add the Cargo.toml files to your commit had a bug in which if your repository did not have nested Cargo.toml files (e.g. your repo is not a workspace, just a single crate), then you would fail with the error:

`fatal: pathspec '**/Cargo.toml' did not match any files`

This can be fixed by changing the shell options (shopt) to enable ** to match directories recursivly (-s globstar).