### PR TITLE
release worfklow: Bugfixes

### DIFF
--- a/.github/workflows/CrateVersionUpdater.yml
+++ b/.github/workflows/CrateVersionUpdater.yml
@@ -64,7 +64,8 @@ jobs:
 
             const draft = releases.find(r => r.draft);
             if (!draft) {
-              core.setFailed("No draft release found.");
+              core.info("No draft release found.");
+              core.setOutput("tag", "");
               return;
             }
 
@@ -77,19 +78,23 @@ jobs:
             core.setOutput("tag", tag);
 
       - name: Update git credentials
+        if: steps.release_tag.outputs.tag != ''
         run: |
           git config --global user.name "patina-automation[bot]"
           git config --global user.email "patina@microsoft.com"
 
       - name: Checkout New Branch
+        if: steps.release_tag.outputs.tag != ''
         run: |
           git checkout -b "github-actions/release-version-update-${{ steps.release_tag.outputs.tag }}"
       
       - name: Run Cargo Release to Update Versions
+        if: steps.release_tag.outputs.tag != ''
         run: |
           cargo release version ${{ steps.release_tag.outputs.tag }} --execute --no-confirm
       
       - name: Push Changes
+        if: steps.release_tag.outputs.tag != ''
         run: |
           shopt -s globstar
           git add **/Cargo.toml
@@ -97,6 +102,7 @@ jobs:
           git push origin HEAD:github-actions/release-version-update --force
       
       - name: Create or Update Pull Request
+        if: steps.release_tag.outputs.tag != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -140,4 +140,4 @@ jobs:
       - name: Publish to crates.io
         if: steps.validate-version-updated.outputs.version-updated == 'true'
         run: |
-          cargo release -x --no-tag --no-push --workspace
+          cargo release -x --no-tag --no-push --workspace --no-confirm


### PR DESCRIPTION
This commit fixes two bugs in the release process. The first, associated with `CrateVersionUpdater.yml` fixes an issue that causes the workflow to fail in error if a release draft is not present. This choice was purposeful as running the workflow when a release draft did not exist seemed like an error. However, this is a common occurrence immediately after a release has been performed. A new draft will not be created until another PR merged.

The second, associated with `ReleaseWorkflow.yml` fixes a bug in which I forgot to add `--no-confirm`, which is necessary for the publishing to occur without human interference.