### PR TITLE
.sync/ci-workflow.yml: Apply a safe filter to `run-release-dry-run`

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -376,8 +376,7 @@ group:
           - "build-x64"
           - "build-aarch64"
         run_cargo_vet: false
-        run_release_dry_run: >
-          ${{ !contains(github.event.pull_request.body, "- [x] Creates a new crate?") }}
+        run_release_dry_run: "${{ !contains(github.event.pull_request.body, '- [x] Creates a new crate?') }}"
         test_mdbook: true
         trigger_branches:
           - "main"

--- a/.sync/workflows/leaf/ci-workflow.yml
+++ b/.sync/workflows/leaf/ci-workflow.yml
@@ -42,7 +42,7 @@ jobs:
     with:
       build-tasks: {{ build_tasks | join(",") }}
       run-cargo-vet: {{ run_cargo_vet }}
-      run-release-dry-run: {{ run_release_dry_run }}
+      run-release-dry-run: {{ run_release_dry_run | safe }}
     secrets: inherit
   {% if test_mdbook -%}
 {{"  "}}mdbook_docs_test:


### PR DESCRIPTION
To prevent quotes from being autoescaped, use the `safe` filter when substituting the parameter value.

---

Prevents the quotes from being placed like this:

```
${{ !contains(github.event.pull_request.body, &quot;- [x] Creates a new crate?&quot;) }}
```