### PR TITLE
.sync/publish-release.yml: Remove default token permissions

### DIFF
--- a/.sync/workflows/leaf/publish-release.yml
+++ b/.sync/workflows/leaf/publish-release.yml
@@ -31,6 +31,3 @@ jobs:
     with:
       ignore-prefix: 'patina-v'
     secrets: inherit
-    permissions:
-      contents: write
-      actions: read


### PR DESCRIPTION
The default token permissions do not need to be modified since a GitHub app-derived token is used for authentication.