### PR TITLE
.sync/markdownlint.yaml: Add iframe as an allowed element

### DIFF
--- a/.sync/markdownlint/.markdownlint.yaml
+++ b/.sync/markdownlint/.markdownlint.yaml
@@ -9,5 +9,5 @@
 {
     "default": true,
     "MD013": {"line_length": 120, "code_blocks": false, "tables": false},
-    "MD033": {"allowed_elements": ["br", "center", "div"]}
+    "MD033": {"allowed_elements": ["br", "center", "div", "iframe"]}
 }


### PR DESCRIPTION
Allow `iframe` elements to be used in markdown. This is currently used to embed videos in the published mdbook.