### PR TITLE
Exclude the patina-automation bot in release notes

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -153,13 +153,17 @@
   description: Notes from an organized meeting
   color: 'd9ee5d'
   aliases: []
-- name: type:submodules
-  description: Pull requests that update submodules
-  color: '000000'
+- name: type:patina-bot
+  description: Pull requests opened by patina-automation[bot]
+  color: '1f618d'
   aliases: []
 - name: type:question
   description: Further information is requested
   color: 'd876e3'
+  aliases: []
+- name: type:submodules
+  description: Pull requests that update submodules
+  color: '000000'
   aliases: []
 
 - name: urgency:low

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -53,3 +53,23 @@ jobs:
           enable-versioned-regex: 0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+
+      - name: Label patina-automation[bot] PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            if (!context.payload.pull_request) {
+              core.info('No pull_request payload; skipping patina-automation[bot] labeling');
+              return;
+            }
+            const pr_author = context.payload.pull_request.user.login;
+            if (pr_author === 'patina-automation[bot]') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['type:patina-bot']
+              });
+              core.info('Applied label "type:patina-bot" for patina-automation[bot]');
+            }

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,4 +30,4 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set patina_devops = "v0.3.1" %}
+{% set patina_devops = "v0.3.2" %}

--- a/.sync/workflows/config/release-draft-config.yml
+++ b/.sync/workflows/config/release-draft-config.yml
@@ -88,6 +88,7 @@ exclude-labels:
   - 'type:dependabot'
   - 'type:file-sync'
   - 'type:notes'
+  - 'type:patina-bot'
   - 'type:question'
 
 exclude-contributors:


### PR DESCRIPTION
Add a label to PRs created by the patina-automation bot so they can easily be excluded from release notes.

---

This change (https://github.com/OpenDevicePartnership/patina/commit/334853c11ab7779ce6299a22841fcf6ec6ccc5a4) in the patina repo prevented `patina-automation[bot]` from appearing as a contributor but did not prevent its actual PR from being included in the release notes. Now, a label `type:patina-bot` is applied to its PRs and those labels are marked for exclusion from the release notes.