### PR TITLE
.sync/config.toml: Customize link section inclusion

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -139,12 +139,34 @@ group:
   - files:
     - source: .sync/rust/config.toml
       dest: .cargo/config.toml
+      template:
+        include_uefi_target_rules: false
     repos: |
       OpenDevicePartnership/patina
-      OpenDevicePartnership/patina-dxe-core-qemu
       OpenDevicePartnership/patina-fw-patcher
       OpenDevicePartnership/patina-mtrr
       OpenDevicePartnership/patina-paging
+
+  - files:
+    - source: .sync/rust/config.toml
+      dest: .cargo/config.toml
+      template:
+        include_uefi_target_rules: true
+        aarch64_pdb_name: qemu_sbsa_dxe_core.pdb
+        x86_64_pdb_name: qemu_q35_dxe_core.pdb
+    repos: |
+      OpenDevicePartnership/patina-dxe-core-qemu
+
+  # Note: The UEFI shell application capture tool will have a different name.
+  #       This rule is specifically matching the DXE Core replacement binary.
+  - files:
+    - source: .sync/rust/config.toml
+      dest: .cargo/config.toml
+      template:
+        include_uefi_target_rules: true
+        aarch64_pdb_name: qemu_dxe_readiness_capture.pdb
+        x86_64_pdb_name: qemu_dxe_readiness_capture.pdb
+    repos: |
       OpenDevicePartnership/patina-readiness-tool
 
 # Rust Configuration - Cargo Deny

--- a/.sync/rust/config.toml
+++ b/.sync/rust/config.toml
@@ -11,12 +11,13 @@ git-fetch-with-cli = true
 [resolver]
 incompatible-rust-versions = "fallback"
 
+{% if include_uefi_target_rules %}
 [target.x86_64-unknown-uefi]
 rustflags = [
     "-C", "link-arg=/base:0x0",
     "-C", "link-arg=/subsystem:efi_boot_service_driver",
     "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb",
+    "-C", "link-arg=/PDBALTPATH:{{ x86_64_pdb_name | default("x86_64_bin.pdb") }}",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -24,5 +25,6 @@ rustflags = [
     "-C", "link-arg=/base:0x0",
     "-C", "link-arg=/subsystem:efi_boot_service_driver",
     "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb",
+    "-C", "link-arg=/PDBALTPATH:{{ aarch64_pdb_name | default("aarch64_bin.pdb") }}",
 ]
+{% endif %}


### PR DESCRIPTION
Add a template parameter called `include_uefi_target_rules` to control whether the linker arguments for UEFI targets are defined for `rustflags`.

This is currently only needed for building UEFI binaries in the patina-dxe-core-qemu and patina-readiness-tool repos.

PDB names can be customized for the `PDBALTPATH` parameter independently for each target.

---

### File Sync Tests

- Example of a `false` scenario such as the `patina` repo: https://github.com/makubacki/patina/commit/0bfcf83bc0d6b811014c45bce97b2f303ab732d4
- Example of a `true` scenario such as the `patina-dxe-core-qemu` repo: https://github.com/makubacki/patina-dxe-core-qemu/commit/16091818f8447392d3335db8ecc0d6302152e0e0