### PR TITLE
Update label syntax for actions/labeler v6

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,4 +30,4 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set patina_devops = "v0.3.3" %}
+{% set patina_devops = "v0.3.4" %}

--- a/.sync/workflows/config/label-issues/file-paths.yml
+++ b/.sync/workflows/config/label-issues/file-paths.yml
@@ -15,5 +15,6 @@
 
 # Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
 
-language:python:
-    - '**/*.py'
+'language:python':
+- changed-files:
+  - any-glob-to-any-file: '**/*.py'


### PR DESCRIPTION
The syntax for file paths needs to be updated after updating to v6 of the action in:

https://github.com/OpenDevicePartnership/patina-devops/commit/1a7c1e55f3d65d16c82d10f05dab5629c8e281ce

---

Tested on fork in this action run: https://github.com/makubacki/patina/actions/runs/19182728691/job/54843079722