### PR TITLE
Files.yml: Update .gitignore in Rust repos

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -62,11 +62,11 @@ group:
       template:
         ignored_files:
           - '*.profraw'
-          - '**/pdbhelper.dll'
-          - '/target'
+          - '**/target'
           - 'Cargo.lock'
           - 'docs/book/'
           - 'docs/target/'
+          - '.vscode/launch.json'
     repos: |
       OpenDevicePartnership/patina
       OpenDevicePartnership/patina-dxe-core-qemu


### PR DESCRIPTION
Pull in the changes made to .gitignore locally in the patina repo in: https://github.com/OpenDevicePartnership/patina/commit/228bfbadec6cf478ffe8f7d76bb67be32ee56f49

This should resolve as a no-op to that repo in future file syncs.