### PR TITLE
Dependabot: Update syntax for ignore dependency names. 

### DIFF
--- a/.sync/dependabot/dependabot.yml
+++ b/.sync/dependabot/dependabot.yml
@@ -40,7 +40,7 @@ updates:
       time: "06:00"
     ignore:
       # Ignore dependencies that are synced from patina-devops
-      - dependency-name: "OpenDevicePartnership/patina-devops"
+      - dependency-name: "OpenDevicePartnership/patina-devops*"
     commit-message:
       prefix: "GitHub Action"
     labels:


### PR DESCRIPTION
Dependabot action updates ignore syntax needed modified to ignore actions. This was tracked to the following documentation:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--