### PR TITLE
Makefile.toml: Don't Build Doc Dependencies for CI

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -373,7 +373,7 @@ run_task = "patch"
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
 
 [tasks.doc-open]
 description = "Builds all rust documentation in the workspace and opens the documentation Example `cargo make doc-open`"

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -141,7 +141,7 @@ args = ["clippy", "--all-targets", "--", "-D", "warnings"]
 env = { RUSTDOCFLAGS = "-D warnings"}
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
 
 [tasks.doc-open]
 env = { RUSTDOCFLAGS = "-D warnings"}

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -116,7 +116,7 @@ args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 env = { RUSTDOCFLAGS = "-D warnings"}
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
 
 [tasks.doc-open]
 env = { RUSTDOCFLAGS = "-D warnings"}

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -194,7 +194,7 @@ dependencies = ["individual-package-targets"]
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
 
 [tasks.doc-open]
 description = "Builds all rust documentation in the workspace and opens the documentation. Example `cargo make doc-open`"


### PR DESCRIPTION
Currently, we run cargo doc in cargo make all and in CI to validate our docs are not broken. However, this automatically builds dependencies, which is slow, needless for this case, and can cause a CI break for us if a dependency has broken docs.

This adds --no-deps to cargo make doc to not build dependencies. On a local system that changed a clean build of cargo make doc from 5m 04s to 38s.

For the locally built docs case, cargo make doc-open will build all docs, including dependencies and open it locally.