### PR TITLE
CiWorkflow.yml: Add artifact upload parameter

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: true
         type: boolean
+      additional-artifacts:
+        description: "Additional artifact paths to upload (newline-separated list of paths)"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   basic_ci:
@@ -112,6 +117,14 @@ jobs:
           path: |
             Cargo.lock
             target/cobertura.xml
+
+      - name: Upload Additional Artifacts
+        if: ${{ inputs.additional-artifacts != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ runner.os }}-additional-artifacts
+          path: ${{ inputs.additional-artifacts }}
+          if-no-files-found: warn
 
   finalize:
     name: Finalize


### PR DESCRIPTION
Allow a caller to specify a list of artifacts to upload. This allows build output to efficiently be uploaded from the build already performed in the job.