### PR TITLE
Files.yml: Add custom patina-readiness-tool settings

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -168,13 +168,39 @@ group:
   - files:
     - source: .sync/rust/deny.toml
       dest: deny.toml
+      template:
+        denied_crates:
+          - '{ crate = "tiny-keccak", reason = "Not updated in 5 years. Use alternative." }'
+        ignored_rust_security_advisories:
+          # Note: `paste` is currently used in `gdbstub` brought in by `patina_debugger`
+          - '{ id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." }'
+        license_exceptions:
+          - '{ allow = ["0BSD"], crate = "managed" }'
+          - '{ allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib" }'
+          - '{ allow = ["Unicode-3.0"], crate = "unicode-ident" }'
+        skipped_crates:
+          - '{ crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86." }'
     repos: |
       OpenDevicePartnership/patina
-      OpenDevicePartnership/patina-apps
       OpenDevicePartnership/patina-dxe-core-qemu
-      OpenDevicePartnership/patina-fw-patcher
       OpenDevicePartnership/patina-mtrr
       OpenDevicePartnership/patina-paging
+
+  - files:
+    - source: .sync/rust/deny.toml
+      dest: deny.toml
+      template:
+        denied_crates:
+          - '{ crate = "tiny-keccak", reason = "Not updated in 5 years. Use alternative." }'
+        ignored_rust_security_advisories:
+        license_exceptions:
+          - '{ allow = ["Unicode-3.0"], crate = "unicode-ident" }'
+          - '{ allow = ["MPL-2.0"], crate = "colored" }'
+          - '{ allow = ["MPL-2.0"], crate = "ucs2" }'
+        skipped_crates:
+          - '{ crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86." }'
+          - '{ crate = "windows-sys", reason = "https://crates.io/crates/colored latest (v3.0.0) uses 0.59. https://crates.io/crates/anstyle-query latest (v1.1.5) uses 0.61." }'
+    repos: |
       OpenDevicePartnership/patina-readiness-tool
 
 # Rust Configuration - Cargo Make

--- a/.sync/rust/deny.toml
+++ b/.sync/rust/deny.toml
@@ -60,8 +60,11 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 
-    # Note: `paste` is currently used in `gdbstub` brought in by `patina_debugger`
-    { id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." },
+    {% if ignored_rust_security_advisories and ignored_rust_security_advisories|length > 0 %}
+    {{ (ignored_rust_security_advisories | join(",\n    " )) | safe }}
+    {% else %}
+    {{ "# None right now" }}
+    {% endif %}
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -92,9 +95,11 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
-    { allow = ["0BSD"], crate = "managed" },                # todo: follow up on crate license
-    { allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib"}, # todo: follow up on crate license (via brotli-decompressor)
-    { allow = ["Unicode-3.0"], crate = "unicode-ident" },   # todo: follow up on crate license
+    {% if license_exceptions and license_exceptions|length > 0 %}
+    {{ (license_exceptions | join(",\n    ")) | safe }}
+    {% else %}
+    {{ "# None right now" }}
+    {% endif %}
 ]
 
 [licenses.private]
@@ -142,7 +147,11 @@ deny = [
     # Wrapper crates can optionally be specified to allow the crate when it
     # is a direct dependency of the otherwise banned crate
     #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
-    { crate = "tiny-keccak", reason = "Not updated in 5 years. Use alternative."},
+    {% if denied_crates and denied_crates|length > 0 %}
+    {{ (denied_crates | join(",\n    ")) | safe }}
+    {% else %}
+    {{ "# None right now" }}
+    {% endif %}
 ]
 
 # List of features to allow/deny
@@ -173,7 +182,11 @@ skip = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 
-    { crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86."}
+    {% if skipped_crates and skipped_crates|length > 0 %}
+    {{ (skipped_crates | join(",\n    ")) | safe}}
+    {% else %}
+    {{ "# None right now" }}
+    {% endif %}
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
These repos are using the current deny.toml config file as-is today:

- `patina`
- `patina-dxe-core-qemu`
- `patina-mtrr`
- `patina-paging`

`patina-readiness-tool` needs a few settings customized. This keeps project-level settings consistent between all repos while allowing common configuration points to be compared and edited in a single location across all repos.

---

Example syncs on forks with these changes:

- https://github.com/makubacki/patina-readiness-tool/pull/2
- https://github.com/makubacki/patina/pull/6