### PR TITLE
Add arm64 CI runner & fix cache and upload keys

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -27,7 +27,7 @@ runs:
         path: |
           ~/.cargo/bin/
           ~/.rustup/toolchains/
-        key: ${{ runner.os }}-rust-tools-${{ hashFiles(inputs.rust-toolchain-file) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-rust-tools-${{ hashFiles(inputs.rust-toolchain-file) }}
 
     # Installs the toolchain specified in the rust-toolchain.toml file if rustup >= 1.28.0
     #

--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, ubuntu-24.04-arm ]
 
     steps:
       - name: ✅ Checkout Repository ✅
@@ -113,7 +113,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ runner.os }}-ci-artifacts
+          name: ${{ runner.os }}-${{ runner.arch }}-ci-artifacts
           path: |
             Cargo.lock
             target/cobertura.xml
@@ -122,7 +122,7 @@ jobs:
         if: ${{ inputs.additional-artifacts != '' }}
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ runner.os }}-additional-artifacts
+          name: ${{ runner.os }}-${{ runner.arch }}-additional-artifacts
           path: ${{ inputs.additional-artifacts }}
           if-no-files-found: warn
 


### PR DESCRIPTION
- Introduces a ubuntu-24.04-arm runner to the CI workflow to verify compatibility with ARM64 development environments.
- Updates cache and artifact keys to include the runner architecture, to prevent conflicts between x86_64 and Arm64.

Tested in forked repo: https://github.com/cfernald/patina/actions/runs/19413067151/job/55537282932?pr=2

Will hold until all dependent repos are fixed for arm64 compilation.