### PR TITLE
codecov: Remove header from comment

### DIFF
--- a/.sync/codecov/codecov.yml
+++ b/.sync/codecov/codecov.yml
@@ -28,5 +28,6 @@ coverage:
         only_pulls: true
 comment:
   after_n_builds: 2
-  layout: "condensed_header, condensed_files, condensed_footer"
+  layout: "condensed_files, condensed_footer"
   hide_project_coverage: true # Only show patch coverage in a PR comment
+


### PR DESCRIPTION
Currently, the codecov commenter posts a header which (most of the time) has a big red "X" on it. This can be confusing when you see the "X" and think you are failing, even though the actual CI check is passing because you are meeting the 80% threshold.

This PR removes the header all together, since this commentor is purely informational, to make it easy to see what lines of code do not have associated tests