### PR TITLE
CiWorkflow.yml: Move clippy to the Rust CI job

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Run cargo-deny
         run: cargo make deny
 
-      - name: Run cargo-clippy
-        run: cargo make clippy
-
       - name: Test Documentation
         run: cargo test --doc
 
@@ -87,6 +84,9 @@ jobs:
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@main
+
+      - name: Run cargo-clippy
+        run: cargo make clippy
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage


### PR DESCRIPTION
Clippy is dependent on conditional compilation configurations such as the target architecture, which leads to issues such as [patina#1092].

Having clippy be part of the Rust CI job should remedy this since it runs on the `ubuntu-24.04-arm` runner.

[patina#1092]: https://github.com/OpenDevicePartnership/patina/issues/1092