### PR TITLE
.sync/Makefiles: Add --doctests to test task

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -109,7 +109,7 @@ description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
-args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
+args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["llvm-cov-clean"]
 
 [tasks.coverage-lcov]

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -84,7 +84,7 @@ description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
-args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
+args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["llvm-cov-clean"]
 
 [tasks.coverage-lcov]

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -155,7 +155,7 @@ description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
-args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
+args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["individual-package-targets", "llvm-cov-clean"]
 
 [tasks.coverage-lcov]


### PR DESCRIPTION
Runs doc tests during the `test` task to validate doc examples and include their coverage in reports.