### PR TITLE
Add template parameter to Rust toolchain file to add additional targets

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -255,6 +255,17 @@ group:
       OpenDevicePartnership/patina-mtrr
       OpenDevicePartnership/patina-paging
       OpenDevicePartnership/patina-qemu
+
+  - files:
+    - source: .sync/rust/rust-toolchain.toml
+      dest: rust-toolchain.toml
+      template:
+        additional_targets:
+          - "x86_64-pc-windows-msvc"
+          - "aarch64-pc-windows-msvc"
+          - "x86_64-unknown-linux-gnu"
+          - "aarch64-unknown-linux-gnu"
+    repos: |
       OpenDevicePartnership/patina-readiness-tool
 
 # Rust Configuration - Rustfmt

--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -6,7 +6,7 @@
 
 [toolchain]
 channel = "nightly-2025-09-19" # One day post 1.90.0
-targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"]
+targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
 # A custom section for CI pipelines to install tools


### PR DESCRIPTION
- Ensure validator binary builds for the following target triples:
  - x86_64-pc-windows-msvc
  - aarch64-pc-windows-msvc
  - x86_64-unknown-linux-gnu
  - aarch64-unknown-linux-gnu
- This change enables the patina readiness tool GitHub release to include all supported binary flavors(after a follow up fix in readiness repo).
```
    ├───aarch64-pc-windows-msvc
    │   └───debug
    │           dxe_readiness_validator.exe
    │           dxe_readiness_validator.pdb
    ├───x86_64-pc-windows-msvc
    │   └───debug
    │           dxe_readiness_validator.exe
    │           dxe_readiness_validator.pdb
    ├───x86_64-unknown-linux-gnu
    │    └───debug
    │            dxe_readiness_validator
    └───aarch64-unknown-linux-gnu
        └───debug
                dxe_readiness_validator
```