### PR TITLE
Update Rust toolchain version to nightly-2025-12-12

### DIFF
--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2025-09-19" # One day post 1.90.0
+channel = "nightly-2025-12-12" # One day post 1.92.0
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
This commit updates rust toolchain version to 2025-12-12, which is one day post 1.92.0 release. This file is sync'd to all applicable repositories via the file syncer.

ref: https://github.com/OpenDevicePartnership/patina/issues/1190