### PR TITLE
rust-toolchain.toml: use an empty additional_targets list when no extra targets are needed

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -247,6 +247,8 @@ group:
   - files:
     - source: .sync/rust/rust-toolchain.toml
       dest: rust-toolchain.toml
+      template:
+        additional_targets: []
     repos: |
       OpenDevicePartnership/patina
       OpenDevicePartnership/patina-apps


### PR DESCRIPTION
- Address the failure in processing the nunjucks template introduced in recent https://github.com/OpenDevicePartnership/patina-devops/pull/55
- Validated on a private fork https://github.com/vineelko/patina-devops/actions/runs/20178244757