### PR TITLE
.sync/rust-toolchain.toml: Update cargo-deny to v0.18

### DIFF
--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -11,7 +11,7 @@ components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
 # A custom section for CI pipelines to install tools
 [tools]
-cargo-deny = "^0.17"
+cargo-deny = "^0.18"
 cargo-geiger = "0.13.0"
 cargo-llvm-cov = "0.6.18"
 cargo-make = "0.37.21"


### PR DESCRIPTION
Update to version 0.18 to pick up the fix for the following issue:

https://github.com/EmbarkStudios/cargo-deny/issues/804

In the v0.18.6 release of cargo-deny:

https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.18.6

---

Fixes this issue observed in patina-dxe-core-qemu:

```
Error: -20 00:22:52 [ERROR] failed to load advisory database: parse error: error parsing /home/runner/.cargo/advisory-dbs/github.com-9b36585d9d99f7b3/crates/cap-primitives/RUSTSEC-2024-0445.md: parse error: TOML parse error at line 8, column 8
  |
8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unsupported CVSS version: 4.0
```