### PR TITLE
update cargo-binstall install action

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -43,7 +43,7 @@ runs:
       continue-on-error: true
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.10.17
+      uses: cargo-bins/cargo-binstall@v1.16.5
       if: steps.tool-cache.outputs.cache-hit != 'true'
 
     # Read any tools from rust-toolchain.toml file and installs them


### PR DESCRIPTION
This commit updates the action that installs cargo-binstall to latest, which fixes an issue we were experiencing when attempting to install cargo-binstall during a cache miss.

Closes #60 

Fix works as shown here: https://github.com/OpenDevicePartnership/patina/actions/runs/20439368694/job/58728410115?pr=1207

