### PR TITLE
.sync/publish-mdbook.yml: Use main for rust-tool-cache action

### DIFF
--- a/.sync/workflows/leaf/publish-mdbook.yml
+++ b/.sync/workflows/leaf/publish-mdbook.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@{% endraw %}{{ sync_version.patina_devops }}
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@main
       - name: 📄 Build Documentation 📄
         run: mdbook build docs
 
@@ -68,5 +68,5 @@ jobs:
       - name: 🚀 Deploy Github Pages Site 🚀
         uses: actions/deploy-pages@v4
         with:
-          token: {% raw %}${{ github.token }}{% endraw %}
+          token: ${{ github.token }}
           artifact_name: github-pages


### PR DESCRIPTION
The action may have dependencies that need to be updated to keep pace with the latest build depenencies used elsewhere in Patina. Switch to using `main` to always pick up the latest action code.