### PR TITLE
publish-mdbook.yml: Do not treat the sync file as a template

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -619,7 +619,6 @@ group:
   - files:
     - source: .sync/workflows/leaf/publish-mdbook.yml
       dest: .github/workflows/publish-mdbook.yml
-      template: true
     repos: |
       OpenDevicePartnership/patina
 

--- a/.sync/workflows/leaf/publish-mdbook.yml
+++ b/.sync/workflows/leaf/publish-mdbook.yml
@@ -14,9 +14,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-{%- import '../../Version.njk' as sync_version -%}
-{%- raw -%}
-
 name: Publish Documentation
 
 on:


### PR DESCRIPTION
The file originally imported `Version.njk` to get the `patina_devops` version set in the file. The file simply references the `main` branch now, so the import is unnecessary and the file does not need to be treated as a Nunjucks template.