### PR TITLE
Version.njk: Update version to v0.3.8

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,4 +30,4 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set patina_devops = "v0.3.6" %}
+{% set patina_devops = "v0.3.8" %}


### PR DESCRIPTION
Updates the version for an upcoming patina-devops release.

---

Note: The patina-devops v0.3.7 release was made on GitHub without
this file being updated so this commit takes the version from
v0.3.6 to v0.3.8 directly.