### PR TITLE
Minor: Git ignore .edkCode for C Code

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -86,6 +86,7 @@ group:
       template:
         ignored_files:
           - '__pycache__/'
+          - '.edkCode/'
           - '.git_credentials'
           - '*_extdep/'
           - '*.bak'


### PR DESCRIPTION
Minor: Git ignore .edkCode for C Code

- `.edkCode` is created by `edk2code` VS code extension.