### PR TITLE
Remove resolver.incompatible-rust-version=fallback from config.toml

### DIFF
--- a/.sync/rust/config.toml
+++ b/.sync/rust/config.toml
@@ -7,10 +7,6 @@
 [net]
 git-fetch-with-cli = true
 
-# This tells cargo to consider the MSV of rust for our crate vs our dependencies.
-[resolver]
-incompatible-rust-versions = "fallback"
-
 {% if include_uefi_target_rules %}
 [target.x86_64-unknown-uefi]
 rustflags = [


### PR DESCRIPTION
We are currently setting this field even though it is the default for Rust edition 2024. Drop it.

See https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions for details.