### PR TITLE
Makefile.toml: Add --all-targets --all-features to check_test

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -123,7 +123,7 @@ args = ["check", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARG
 description = "Checks rust test code for build errors with results."
 private = true
 command = "cargo"
-args = ["test", "--no-run", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
 
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"


### PR DESCRIPTION
Currently, the check_code task runs with --all-targets --all-features but the check_test task does not. This can cause errors/warnings to show up in the check_test task that should not be there.