### PR TITLE
File Sync .gitignore: Remove CONFIG generated path

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -93,7 +93,6 @@ group:
           - '*.pyc'
           - '*.vcxproj.user'
           - '/**/AutoGen/**'
-          - '/**/Include/Generated/**'
           - '/Build/'
           - '/Conf/'
           - '/target'


### PR DESCRIPTION
patina-qemu no longer uses mu_feature_config. As a result drop the autogen path from .gitignore.