### PR TITLE
rust-tool-cache: Replace cargo-binstall action with install script

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -43,7 +43,9 @@ runs:
       continue-on-error: true
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.16.5
+      shell: bash
+      run: |
+        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       if: steps.tool-cache.outputs.cache-hit != 'true'
 
     # Read any tools from rust-toolchain.toml file and installs them


### PR DESCRIPTION
The "Install cargo-binstall" step previously used the `cargo-bins/cargo-binstall` action to install cargo-binstall on a cache miss.

This action fails to run successfully in a container environment. (e.g. with ghcr.io/microsoft/mu_devops/ubuntu-24-test:latest):

```
bash: /home/runner/work/_actions/cargo-bins/cargo-binstall/v1.17.5/install-from-binstall-release.sh: No such file or directory
````

As far as I can tell, this was not an issue before because all workflows that used the action were running directly on github-hosted runners (not containers). Because the action is JavaScript, it runs in a slightly separate context from the container shell and calls within the action are modifying the action runner host environment rather than the container environment.

Future workflows will build Rust code and run QEMU in the same container environment.

This change simplifies binstall installation by replacing the action with the official cargo-binstall install script delivered with curl. Following the command given in https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#linux-and-macos.

This approach:

- Is container-agnostic: the script installs directly into the cargo bin directory without relying on runner-specific tooling or JavaScript action infrastructure
- Removes maintenance of an action dependency
- Works on both Linux and Windows runners
  - GitHub Windows runners have bash support