### PR TITLE
.sync/leaf/ci-workflow.yml: Add concurrency group

### DIFF
--- a/.sync/workflows/leaf/ci-workflow.yml
+++ b/.sync/workflows/leaf/ci-workflow.yml
@@ -35,6 +35,17 @@ on:
 {{"      -"}} {{ branch }}
 {% endfor %}
 
+{% raw -%}
+# Do not allow more than one instance of this workflow to run at the same
+# time for the same PR ref (branch). Prefer head_ref but fall back to ref
+# for push events.
+# - head_ref example: "branch_name"
+# - ref example: "refs/pull/7/merge"
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+{% endraw %}
 jobs:
   ci_workflow:
     name: Run


### PR DESCRIPTION
Prevent parallel runs of the CI workflow for the same branch by adding a concurrency group based on the branch name.

More details:

https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency