### PR TITLE
.sync/Makefiles: Add test-asan task for AddressSanitizer testing

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -170,6 +170,58 @@ release ${2}
 release ${3}
 '''
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace --features std
+'''
+
 [tasks.patch]
 private = true
 script_runner = "@duckscript"

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -131,6 +131,58 @@ description = "Build and run all tests and calculate coverage (runs test once an
 dependencies = ["test", "coverage-lcov", "coverage-html"]
 clear = true
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace --features std
+'''
+
 [tasks.clippy]
 description = "Run cargo clippy."
 clear = true

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -106,6 +106,58 @@ description = "Build and run all tests and calculate coverage (runs test once an
 dependencies = ["test", "coverage-lcov", "coverage-html"]
 clear = true
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace
+'''
+
 [tasks.clippy]
 description = "Run cargo clippy."
 clear = true

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -146,6 +146,58 @@ description = "Build and run all tests and calculate coverage (runs test once an
 dependencies = ["coverage-test", "coverage-lcov", "coverage-html"]
 clear = true
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace
+'''
+
 [tasks.clippy]
 description = "Run cargo clippy."
 clear = true

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -158,6 +158,58 @@ command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["individual-package-targets", "llvm-cov-clean"]
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace --features std
+'''
+
 [tasks.coverage-lcov]
 description = "Generate an LCOV coverage report from collected data."
 install_crate = false


### PR DESCRIPTION
Adds a `test-asan` task that runs tests  with AddressSanitizer (`-Zsanitizer=address`) enabled. The task supports Windows x64 and Linux hosts.

Full task command: `cargo make test-asan`

On Windows [1], ASan-instrumented binaries require the MSVC ASan runtime DLL (`clang_rt.asan_dynamic-x86_64.dll`) to be on PATH at runtime so that's done as part of the task setup. The DLL location is resolved using the VC toolset installation path from `vswhere` [2].

On Linux, no additional setup is needed as the ASan runtime is resolved automatically by the linker.

[1] https://learn.microsoft.com/cpp/sanitizers/asan
[2] https://github.com/microsoft/vswhere/wiki/Find-VC

Some Makefile.toml files have `--features std` present depending on whether the workspace Cargo.toml supports a `std` feature.

A `--print-dll-path` argument is supported on Windows to print the resolved ASan DLL path and exit, which can be useful for adding that to the system PATH when running tests outside of `cargo make`.

---

Tested running `cargo make test-asan` in each repo (on Windows) with the Makefile.toml change applied.