### PR TITLE
Update rust to v1.93.1

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
 UEFI_CRATES = "-p patina_mtrr"
 BUILD_CRATES = "-p patina_mtrr"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
 UEFI_CRATES = "-p patina_paging"
 BUILD_CRATES = "-p patina_paging"
 COV_FLAGS = { value = "--profile test --ignore-filename-regex **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"

--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2025-12-12" # One day post 1.92.0
+channel = "nightly-2026-02-13" # One day post 1.93.1
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
This commit updates rust to a nightly release of rust, dated 1 day post 1.93.1.

This version, as it is nightly, includes nightly features from rust v1.94, which includes the optional file format for the `--timings` report.

ref: https://github.com/rust-lang/cargo/pull/16420