### PR TITLE
Makefile: enable all features for build-lib cmd

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -85,7 +85,7 @@ Example:
 """
 clear = true
 command = "cargo"
-args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(STD_FLAGS, )"]
+args = ["build", "--all-features", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(STD_FLAGS, )"]
 dependencies = ["individual-package-targets"]
 
 [tasks.run-bin]


### PR DESCRIPTION
Updates the build-lib command to include the `--all-features` argument. The build-lib cmd is used when validating all examples in the `patina` mdbook documentation is up to date (can compile and possibly run). Prior to this change, if functionality is gated behind a feature flag, it could not be properly documented with compile-time validation in the patina mdbook documentation.