### PR TITLE
Makefile: align `cargo make all` with CI checks

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -58,13 +58,13 @@ jobs:
         run: cargo make vet
 
       - name: Run cargo-fmt
-        run: cargo fmt --all --check
+        run: cargo make fmt-check
 
       - name: Run cargo-deny
         run: cargo make deny
 
       - name: Test Documentation
-        run: cargo test --doc
+        run: cargo make doc-test
 
       - name: Build documentation
         run: cargo make doc

--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -442,6 +442,18 @@ clear = true
 command = "cargo"
 args = ["fmt", "--all"]
 
+[tasks.fmt-check]
+description = "Check cargo format without modifying files."
+clear = true
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.doc-test]
+description = "Run documentation tests."
+clear = true
+command = "cargo"
+args = ["test", "--doc"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
@@ -510,6 +522,7 @@ cm_run_task bloat-sbsa-exec
 [tasks.all]
 description = "Run all tasks for PR readiness."
 dependencies = [
+    "fmt-check",
     "deny",
     "clippy",
     "cspell",
@@ -521,6 +534,6 @@ dependencies = [
     "sbsa-release",
     "test",
     "coverage",
-    "fmt",
+    "doc-test",
     "doc",
 ]

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -207,6 +207,18 @@ clear = true
 command = "cargo"
 args = ["fmt", "--all"]
 
+[tasks.fmt-check]
+description = "Check cargo format without modifying files."
+clear = true
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.doc-test]
+description = "Run documentation tests."
+clear = true
+command = "cargo"
+args = ["test", "--doc"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
@@ -221,6 +233,7 @@ args = ["deny", "check"]
 [tasks.all]
 description = "Run all tasks for PR readiness."
 dependencies = [
+    "fmt-check",
     "deny",
     "clippy",
     "cspell",
@@ -228,6 +241,6 @@ dependencies = [
     "build-x64",
     "build-aarch64",
     "coverage",
-    "fmt",
+    "doc-test",
     "doc",
 ]

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -182,6 +182,18 @@ clear = true
 command = "cargo"
 args = ["fmt", "--all"]
 
+[tasks.fmt-check]
+description = "Check cargo format without modifying files."
+clear = true
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.doc-test]
+description = "Run documentation tests."
+clear = true
+command = "cargo"
+args = ["test", "--doc"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
@@ -196,12 +208,13 @@ args = ["deny", "check"]
 [tasks.all]
 description = "Run all tasks for PR readiness."
 dependencies = [
+    "fmt-check",
     "deny",
     "clippy",
     "cspell",
     "build-x64",
     "build-aarch64",
     "coverage",
-    "fmt",
+    "doc-test",
     "doc",
 ]

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -216,6 +216,18 @@ clear = true
 command = "cargo"
 args = ["fmt", "--all"]
 
+[tasks.fmt-check]
+description = "Check cargo format without modifying files."
+clear = true
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.doc-test]
+description = "Run documentation tests."
+clear = true
+command = "cargo"
+args = ["test", "--doc"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking."                                                                                                                                     # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**,.azurepipelines/**,dxe_readiness_validator/src/tests/data/*.json}\" ."
@@ -229,4 +241,4 @@ args = ["deny", "check"]
 
 [tasks.all]
 description = "Run all tasks for PR readiness."
-dependencies = ["deny", "clippy", "cspell", "build", "coverage", "fmt", "doc"]
+dependencies = ["fmt-check", "deny", "clippy", "cspell", "build", "coverage", "doc-test", "doc"]

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -266,6 +266,18 @@ clear = true
 command = "cargo"
 args = ["fmt", "--all"]
 
+[tasks.fmt-check]
+description = "Check cargo format without modifying files."
+clear = true
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.doc-test]
+description = "Run documentation tests."
+clear = true
+command = "cargo"
+args = ["test", "--doc"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
@@ -295,6 +307,7 @@ ignore_errors = false
 [tasks.all]
 description = "Run all tasks for PR readiness."
 dependencies = [
+    "fmt-check",
     "deny",
     "cspell",
     "clippy",
@@ -303,6 +316,6 @@ dependencies = [
     "build-aarch64",
     "patina-test",
     "coverage",
-    "fmt",
+    "doc-test",
     "doc",
 ]


### PR DESCRIPTION
The `cargo make all` task is intended for local PR readiness validation, but it diverges from what CI actually checks in two ways:

1. **`fmt` vs `fmt --check`**: The `all` task ran `cargo fmt --all` (which silently fixes formatting) instead of `cargo fmt --all --check` (which fails on unformatted code like CI does). This means `cargo make all` would never catch formatting issues.

2. **Missing `cargo test --doc`**: CI runs `cargo test --doc` separately, but `cargo make all` didn't include it.

### How this was tested

Ran `cargo make fmt-check`, `cargo make doc-test`, and `cargo make all` locally in the patina repo with the equivalent changes applied.