### PR TITLE
.sync/Makefile.toml: Check and test without default features

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Run cargo-clippy
         run: cargo make clippy
 
+      - name: Check no-default-features
+        run: cargo make check-no-default-features
+
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage
 

--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -68,6 +68,23 @@ description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
 run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
+[tasks.check-no-default-features-code]
+description = "Checks rust code compiles without default features."
+private = true
+command = "cargo"
+args = ["check", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features-tests]
+description = "Checks rust test code compiles without default features."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features]
+description = "Checks rust code and tests compile without default features to catch feature-gate regressions."
+clear = true
+run_task = [{ name = ["check-no-default-features-code", "check-no-default-features-tests"], parallel = true }]
+
 [tasks.test]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"
 clear = true
@@ -526,6 +543,7 @@ dependencies = [
     "deny",
     "clippy",
     "cspell",
+    "check-no-default-features",
     "q35",
     "ovmf",
     "sbsa",

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -97,6 +97,23 @@ description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
 run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
+[tasks.check-no-default-features-code]
+description = "Checks rust code compiles without default features."
+private = true
+command = "cargo"
+args = ["check", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features-tests]
+description = "Checks rust test code compiles without default features."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features]
+description = "Checks rust code and tests compile without default features to catch feature-gate regressions."
+clear = true
+run_task = [{ name = ["check-no-default-features-code", "check-no-default-features-tests"], parallel = true }]
+
 [tasks.llvm-cov-clean]
 description = "Clean coverage data"
 private = true
@@ -237,6 +254,7 @@ dependencies = [
     "deny",
     "clippy",
     "cspell",
+    "check-no-default-features",
     "build",
     "build-x64",
     "build-aarch64",

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -72,6 +72,23 @@ description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
 run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
+[tasks.check-no-default-features-code]
+description = "Checks rust code compiles without default features."
+private = true
+command = "cargo"
+args = ["check", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features-tests]
+description = "Checks rust test code compiles without default features."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features]
+description = "Checks rust code and tests compile without default features to catch feature-gate regressions."
+clear = true
+run_task = [{ name = ["check-no-default-features-code", "check-no-default-features-tests"], parallel = true }]
+
 [tasks.llvm-cov-clean]
 description = "Clean coverage data"
 private = true
@@ -212,6 +229,7 @@ dependencies = [
     "deny",
     "clippy",
     "cspell",
+    "check-no-default-features",
     "build-x64",
     "build-aarch64",
     "coverage",

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -125,6 +125,23 @@ private = true
 command = "cargo"
 args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
 
+[tasks.check-no-default-features-code]
+description = "Checks rust code compiles without default features."
+private = true
+command = "cargo"
+args = ["check", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features-tests]
+description = "Checks rust test code compiles without default features."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "--no-default-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check-no-default-features]
+description = "Checks rust code and tests compile without default features to catch feature-gate regressions."
+clear = true
+run_task = [{ name = ["check-no-default-features-code", "check-no-default-features-tests"], parallel = true }]
+
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
@@ -311,6 +328,7 @@ dependencies = [
     "deny",
     "cspell",
     "clippy",
+    "check-no-default-features",
     "build",
     "build-x64",
     "build-aarch64",


### PR DESCRIPTION
Without `--no-default-features` testing, feature-gate regressions go undetected. Code that accidentally uses a gated module or dependency outside its `cfg` fence compiles fine under default features but breaks for consumers that disable defaults.

Adds a higher level `check-no-default-features` task with two parallel subtasks:

  - `check-no-default-features-code`:
    - `cargo check --no-default-features`
  - `check-no-default-features-tests`:
    - `cargo test --no-run --no-default-features`

Runs the task in `cargo make all`.

Makefile-patina-readiness-tool.toml is not updated since it doesn't have a current `check` task and won't benefit much from this change.