### PR TITLE
Update create-github-app-token to v3

### DIFF
--- a/.github/workflows/CalculateUnsafeCode.yml
+++ b/.github/workflows/CalculateUnsafeCode.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/CrateVersionUpdater.yml
+++ b/.github/workflows/CrateVersionUpdater.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Generate Token
         if: steps.check_pr.outputs.skip == 'false'
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/PatinaQemuPrValidationPending.yml
+++ b/.github/workflows/PatinaQemuPrValidationPending.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/PatinaQemuPrValidationPost.yml
+++ b/.github/workflows/PatinaQemuPrValidationPost.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}

--- a/.github/workflows/RustVersionCheck.yml
+++ b/.github/workflows/RustVersionCheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
A major version release of `create-github-app-token` was made on March 13, 2026:

https://github.com/actions/create-github-app-token/releases/tag/v3.0.0

It adds support for Node.js 24, which will resolve this warning currently seen in the GitHub Actions logs:

```
Node.js 20 actions are deprecated. The following actions are running
on Node.js 20 and may not work as expected:

actions/create-github-app-token@v2

Actions will be forced to run with Node.js 24 by default starting
June 2nd, 2026. Please check if updated versions of these actions
are available that support Node.js 24.
```

The two breaking changes in v3 are:

1. Custom proxy handling has been removed. If you use HTTP_PROXY or HTTPS_PROXY, you must now also set NODE_USE_ENV_PROXY=1 on the action step.
2. Requires Actions Runner v2.327.1 or later if you are using a self-hosted runner.

Neither of those apply to Patina. (1) We do not use a proxy, and (2) we use GitHub-hosted runners.