### PR TITLE
.github/PatinaQemuPrValidation.yml: Update upload-artifact action to v7

### DIFF
--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -443,7 +443,7 @@ jobs:
 
       - name: Upload QEMU Linux ${{ matrix.platform }} Logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: qemu-validation-logs-${{ runner.os }}-${{ matrix.platform }}
           path: ${{ env.LOG_DIR }}/*
@@ -623,7 +623,7 @@ jobs:
 
       - name: Upload QEMU Windows Logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: qemu-validation-logs-${{ runner.os }}-Q35
           path: ${{ env.LOG_DIR }}/*
@@ -678,7 +678,7 @@ jobs:
 
       - name: Upload PR Metadata Artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: patina-qemu-pr-metadata
           path: metadata/pr-metadata.json


### PR DESCRIPTION
`upload-artifact action` v7 was released 3 weeks ago. This workflow was written shortly before that. Update to the latest version so the action version used in patina-devops is up to date and consistent across all workflows.