### PR TITLE
.sync/Files.yml: Ignore StMM log files

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -98,6 +98,8 @@ group:
           - '/target'
           - 'BuildConfig.conf'
           - 'tags/'
+          - '*secure_mm.log'
+          - '*secure.log'
     repos: |
       OpenDevicePartnership/patina-edk2
       OpenDevicePartnership/patina-qemu


### PR DESCRIPTION
Commit b2bf562 in patina-qemu recently added the following lines to .gitignore:

  *secure_mm.log
  *secure.log

This change includes the lines in the sync. The lines will be synced to patina-edk2 as well because patina-qemu and patina-edk2 currently share .gitignore file sync settings. Since the lines will have no impact in patina-edk2, this approach is chosen over adding complexity to the sync file to split the .gitignore file sync settings for patina-qemu and patina-edk2.