### PR TITLE
.github: Update setup-patina-qemu-validation to patch, update, then build

### DIFF
--- a/.github/actions/setup-patina-qemu-validation/action.yml
+++ b/.github/actions/setup-patina-qemu-validation/action.yml
@@ -117,6 +117,8 @@ runs:
         # the build uses the local (potentially unreleased) patina source.
         # Otherwise, dependencies resolve from the registry as-is.
         if [ -n "$PATINA_REPO" ]; then
+          run_cmd cargo make q35 -- --crate-patch "$PATINA_REPO" --leave-patch --no-build --exclude-features exit_on_patina_test_failure
+          run_cmd cargo update
           run_cmd cargo make q35 -- --crate-patch "$PATINA_REPO" --leave-patch --exclude-features exit_on_patina_test_failure
         else
           run_cmd cargo make q35 -- --exclude-features exit_on_patina_test_failure


### PR DESCRIPTION
Instead of patch & build, this change updates the flow to patch, update, then build. This allows the build to resolve dependencies from the registry as-is, while still using the local patina source for the crate itself.