### PR TITLE
patina-dxe-core-qemu: Makefile.toml: Drop COMMON_RUSTFLAGS

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -16,7 +16,6 @@ RUSTDOCFLAGS = "-D warnings -D missing_docs"
 # Keep this list in sync with the default features in Cargo.toml.
 BASE_FEATURES = "compatibility_mode_allowed,exit_on_patina_test_failure"
 # Common rustflags used in all targets
-COMMON_RUSTFLAGS = "-C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver -C force-unwind-tables"
 
 [env.development]
 RUSTC_PROFILE = "dev"
@@ -444,32 +443,32 @@ run_task = "build-efi-exec"
 
 [tasks.q35]
 description = """Builds the DEBUG Q35 UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,build_debugger", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,build_debugger", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.q35-release]
 description = """Builds the RELEASE Q35 UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.sbsa]
 description = """Builds the DEBUG SBSA UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.sbsa-release]
 description = """Builds the RELEASE SBSA UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.ovmf]
 description = """Builds the DEBUG OVMF UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,build_debugger,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,build_debugger,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.ovmf-release]
 description = """Builds the RELEASE OVMF UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.doc]


### PR DESCRIPTION
The COMMON_RUSTFLAGS are set in config.toml now and kept in sync between platforms. Drop these duplicating the flags in COMMON_RUSTFLAGS. The base of 0 was decided to be dropped as patina ignores this field and other tools don't like a 0 base.