### PR TITLE
Update action dependencies

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload Coverage Report
         if: github.repository_owner == 'OpenDevicePartnership'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/lcov.info

--- a/.github/workflows/CrateVersionUpdater.yml
+++ b/.github/workflows/CrateVersionUpdater.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check if triggered by a Crate Version Update PR
         id: check_pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             if (context.eventName === 'workflow_run') {
@@ -82,7 +82,7 @@ jobs:
       - name: Get Release Tag
         if: steps.check_pr.outputs.skip == 'false'
         id: release_tag
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -134,7 +134,7 @@ jobs:
 
       - name: Create or Update Pull Request
         if: steps.release_tag.outputs.tag != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -59,7 +59,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Update PR Comment to In-Progress
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -111,7 +111,7 @@ jobs:
 
       - name: Set In-Progress Commit Status
         if: inputs.head-sha != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/PatinaQemuPrValidationPending.yml
+++ b/.github/workflows/PatinaQemuPrValidationPending.yml
@@ -40,7 +40,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Update PR Comment to Pending
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set Pending Commit Status
         if: inputs.head-sha != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/PatinaQemuPrValidationPost.yml
+++ b/.github/workflows/PatinaQemuPrValidationPost.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Download PR Metadata from Triggering Run
         id: download-metadata
         continue-on-error: true
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: patina-qemu-pr-metadata
           path: metadata
@@ -135,7 +135,7 @@ jobs:
 
       - name: Comment on Firmware Assets Not Ready
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -193,7 +193,7 @@ jobs:
 
       - name: Comment on Readiness Mismatch
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete != 'false' && steps.metadata.outputs.readiness_mismatch == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -270,7 +270,7 @@ jobs:
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete != 'false' && steps.metadata.outputs.validation_failed == 'true' && steps.metadata.outputs.readiness_mismatch != 'true'
         id: download-logs
         continue-on-error: true
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: qemu-validation-logs-*
           path: logs
@@ -287,7 +287,7 @@ jobs:
 
       - name: Comment on QEMU Validation Failure
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete != 'false' && steps.metadata.outputs.validation_failed == 'true' && steps.metadata.outputs.readiness_mismatch != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -507,7 +507,7 @@ jobs:
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete != 'false' && steps.metadata.outputs.validation_failed == 'false' && steps.metadata.outputs.readiness_mismatch != 'true'
         id: download-timing-logs
         continue-on-error: true
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           path: logs
@@ -556,7 +556,7 @@ jobs:
 
       - name: Comment on QEMU Validation Success
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped != 'true' && steps.metadata.outputs.assets_complete != 'false' && steps.metadata.outputs.validation_failed == 'false' && steps.metadata.outputs.readiness_mismatch != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -635,7 +635,7 @@ jobs:
 
       - name: Comment on PR Skipped
         if: steps.download-metadata.outcome == 'success' && steps.metadata.outputs.skipped == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -700,7 +700,7 @@ jobs:
 
       - name: Set Final Commit Status
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Get Release Tag
         id: release_tag
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -118,7 +118,7 @@ jobs:
 
       - name: Create Github Release
         if: steps.validate-version-updated.outputs.version-updated == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/RustVersionCheck.yml
+++ b/.github/workflows/RustVersionCheck.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: ✍️ Comment on PR ✍️
         if: steps.check-changes.outputs.rust_version_changed == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Check for Validation Errors
         if: env.VALIDATION_ERROR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             core.setFailed('PR Formatting Validation Check Failed!')

--- a/.sync/workflows/leaf/pull-request-formatting-validator.yml
+++ b/.sync/workflows/leaf/pull-request-formatting-validator.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Check for Validation Errors
         if: env.VALIDATION_ERROR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             core.setFailed('PR Formatting Validation Check Failed!')


### PR DESCRIPTION
Bumps the all-actions-dependencies group with 3 updates:

- [codecov/codecov-action](https://github.com/codecov/codecov-action)
  - Updates `codecov/codecov-action` from 5 to 6
- [actions/github-script](https://github.com/actions/github-script)
  - Updates `actions/github-script` to 9
- [actions/download-artifact](https://github.com/actions/download-artifact)
  - Updates `actions/download-artifact` from 6 to 8

---

Note: Contains all changes from https://github.com/OpenDevicePartnership/patina-devops/pull/121 but with `actions/github-script` updated to `9`, action versions updated in sync files, and the update to `.github/workflows/UpdateReleaseDraft.yml` excluded so that can be individually merged in the future after being tested.