### PR TITLE
Mute geiger command output when running locally

### DIFF
--- a/.github/scripts/analyze_unsafe_code_geiger.py
+++ b/.github/scripts/analyze_unsafe_code_geiger.py
@@ -90,6 +90,7 @@ def run_cargo_geiger(workspace_root: Path, target: str) -> List[Dict]:
 
         geiger_cmd = [
             "cargo", "geiger",
+            "-q",
             "--output-format", "Json",
             "--all-features",
             "--target", target


### PR DESCRIPTION
`-q, --quiet    No output printed to stdout other than the tree.`

otherwise, can produce below output.
```
Failed to match (ignoring source) package: registry+https://githu...

{"$message_type":"artifact","artifact":"E:\\repos\\patina\\target...

 Checking mu_rust_helpers v4.0.0

    Scanning done
{"packages":[{"package":{"id":{"name":"aho-corasick","version":"1...

```