### PR TITLE
.sync: Update mdbook from html directory in publish-mdbook.yml

### DIFF
--- a/.sync/workflows/leaf/publish-mdbook.yml
+++ b/.sync/workflows/leaf/publish-mdbook.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages
-          path: docs/book/
+          path: docs/book/html
 
   publish:
     name: Publish Documentation


### PR DESCRIPTION
Updates the mdbook build artifacts to be uploaded from docs/book/html instead of docs/book because when mdbook has multiple output backends ([output.html] and [output.linkcheck]), it nests output in subdirectories under the build dir (e.g., book/html/, book/linkcheck/) instead of writing directly to book/.