### PR TITLE
.sync: Use pull_request_target for Rust version check workflow

### DIFF
--- a/.sync/workflows/leaf/rust-version-check.yml
+++ b/.sync/workflows/leaf/rust-version-check.yml
@@ -18,7 +18,7 @@
 name: Rust Version Change Detection
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize]
     paths:
@@ -26,9 +26,5 @@ on:
 
 jobs:
   check-rust-version:
-      permissions:
-        pull-requests: write
-        contents: read
-
       uses: OpenDevicePartnership/patina-devops/.github/workflows/RustVersionCheck.yml@{% endraw %}{{ sync_version.patina_devops }}
       secrets: inherit


### PR DESCRIPTION
This workflow needs to use secrets for PRs from public forks, which is not available with the pull_request trigger currently used.

pull_request_target is used instead since it allows access to secrets and the workflow is limited to simple toml parsing and validation not executing any code from the PR.

---

Tested on a pull request to a PR from a public fork here: https://github.com/makubacki/patina/pull/13