### PR TITLE
Pin Windows runners to VS 2022

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, ubuntu-24.04-arm ]
+        os: [ ubuntu-latest, windows-2022, ubuntu-24.04-arm ]
 
     steps:
       - name: ✅ Checkout Repository ✅

--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -585,7 +585,7 @@ jobs:
 
   validate-qemu-windows:
     name: Validate QEMU Q35 (Windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [vars, preflight]
     if: needs.preflight.outputs.assets_complete == 'true'
 


### PR DESCRIPTION
- GitHub will begin upgrading the `windows-latest` runner images to VS 2026 between June 8-15, 2026.
- Pinning workflows to `windows-2022` ensures they continue using VS 2022.