### PR TITLE
MdbookWorkflow.yml: Call the `test-mdbook` task

### DIFF
--- a/.github/workflows/MdbookWorkflow.yml
+++ b/.github/workflows/MdbookWorkflow.yml
@@ -1,5 +1,9 @@
 # A reusable CI workflow that builds and tests a mdbook.
 #
+# This worklfow requires that the caller provide a `test-mdbook` task in their Makefile
+# that builds the mdbook and runs any tests. This allows the same command that is used
+# locally to be run in this workflow.
+#
 ##
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
@@ -7,20 +11,6 @@
 
 on:
   workflow_call:
-    inputs:
-      mdbook-path:
-        description: "Path to the mdbook to build"
-        required: true
-        type: string
-      build-cmd:
-        description: "The build command to run if the mdbook has examples that need extern crates."
-        required: false
-        type: string
-      deps-dir:
-        description: "Directory to the crate(s) build artifacts created by build-cmd e.g. 'target/debug/deps/"
-        required: false
-        default: "target/debug/deps/"
-        type: string
 
 jobs:
   mdbook:
@@ -31,40 +21,10 @@ jobs:
     steps:
       - name: ✅ Checkout Repository ✅
         uses: actions/checkout@v6
-      
+
       - name: 🛠️ Download Rust Tools 🛠️
         uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@main
-        if: ${{ inputs.mdbook-path != '' }}
-      
-      - name: 📖 Build Book 📖
-        run: mdbook build ${{ inputs.mdbook-path }}
-        if: ${{ inputs.mdbook-path != '' }}
-      
-      # If a rust-toolchain file exists, grab the channel from it to use when building examples
-      - name: Get channel / version from toolchain file
-        id: channel
-        run: |
-          if [ -f rust-toolchain.toml ]; then
-            CHANNEL=$(grep -E '^channel\s*=' rust-toolchain.toml | sed -E 's/.*=\s*"([^"]+)".*/\1/')
-            echo "CHANNEL=$CHANNEL"
-            echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
-          else
-            echo "CHANNEL=stable"
-            echo "channel=stable" >> "$GITHUB_OUTPUT"
-          fi
 
-      # If a build-cmd is provided, run it to build the examples
-      - name: Generate Deps
-        id: deps
-        if: ${{ inputs.build-cmd != '' }}
+      - name: 📖 Build and Test Book 📖
         run: |
-          eval "${{ inputs.build-cmd }}"
-          echo "args=-L ${{ inputs.deps-dir }}" >> "$GITHUB_OUTPUT"
-
-      - name: Test Book
-        run: |
-          # mdbook defaults to using the stable toolchain, ignoring any rust-toolchain file
-          # The only way to change this is to invoke mdbook via rustup
-          # If we don't do this, examples are compiled with a different toolchain than our dependencies
-
-          rustup run ${{ steps.channel.outputs.channel }} mdbook test ${{ inputs.mdbook-path }} ${{ steps.deps.outputs.args }}
+          cargo make test-mdbook

--- a/.sync/workflows/leaf/ci-workflow.yml
+++ b/.sync/workflows/leaf/ci-workflow.yml
@@ -58,8 +58,5 @@ jobs:
 {{"  "}}mdbook_docs_test:
     name: Run
     uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@{{ sync_version.patina_devops }}
-    with:
-      mdbook-path: "docs"
-      build-cmd: cargo make build-lib
     secrets: inherit
   {% endif %}


### PR DESCRIPTION
A new task was added to patina called `test-mdbook` that builds and tests the mdbook, encapsulating the logic previously in this workflow. This updates the workflow to reuse that task, so CI and local operations are the same.

The workflow is very simple now but retained as a callable workflow since it still provides a common/reusable place to put any future mdbook related CI logic and reduces some duplication in calling workflows.

The only caller into this reusable workflow today is in the patina repo. The only other Patina-related repo that publishes an mdbook is patina-qemu.

The task can be added to patina-qemu as well when it begins using this workflow.

---

Note: Not considered "breaking" since the workflow is called from `ci-workflow.yml` which is synced from this repo and has been updated to remove the parameters no longer in the workflow. A patina-devops version update must also be made in the same file sync so the file references the latest version that calls the cargo-make task.

---

Tested on fork in this run: https://github.com/makubacki/patina/actions/runs/26247006985/job/77247864402