### PR TITLE
.sync/Files.yml: Drop RUSTSEC-2024-0436

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -174,8 +174,7 @@ group:
         denied_crates:
           - '{ crate = "tiny-keccak", reason = "Not updated in 5 years. Use alternative." }'
         ignored_rust_security_advisories:
-          # Note: `paste` is currently used in `gdbstub` brought in by `patina_debugger`
-          - '{ id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." }'
+          # Example: '{ id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." }'
         license_exceptions:
           - '{ allow = ["0BSD"], crate = "managed" }'
           - '{ allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib" }'


### PR DESCRIPTION
A Rust security advisory was ignored for `paste` was present due to it being unmaintained but brought in through the crate tree. It is no longer needed:

BEFORE:

```
❯ cargo tree -p paste
paste v1.0.15 (proc-macro)
```

NOW:

```
❯ cargo tree -p paste
warning: nothing to print.
```

---

Test file sync with the change to my patina fork: https://github.com/makubacki/patina/pull/15