### PR TITLE
[REBASE & FF] Makefiles: Update Clippy/Check Configuration

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} --timings"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 # Base features included in all platform firmware builds.

--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -9,7 +9,6 @@ default_to_workspace = false
 
 [env]
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
-STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 # Base features included in all platform firmware builds.
@@ -45,29 +44,28 @@ set_env INDIVIDUAL_PACKAGE_TARGETS ${joined_args}
 release ${joined_args}
 '''
 
-[tasks.check_no_std]
-description = "Checks rust code for no_std build errors with results."
+[tasks.check_code_x64]
+description = "Checks rust code for x64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--target", "x86_64-unknown-uefi", "@@split(NO_STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
-[tasks.check_std]
-description = "Checks rust code for std build errors with results."
+[tasks.check_code_aarch64]
+description = "Checks rust code for aarch64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "@@split(STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_tests]
 description = "Checks rust test code for build errors with results."
 private = true
 command = "cargo"
-args = ["test", "--no-run", "@@split(CARGO_MAKE_TASK_ARGS, )"]
-
+args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )",]
 
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
-run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
+run_task = [{ name = ["check_code_x64", "check_code_aarch64", "check_tests"], parallel = true }]
 
 [tasks.check-no-default-features-code]
 description = "Checks rust code compiles without default features."
@@ -482,10 +480,27 @@ command = "cargo"
 args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
 
 [tasks.clippy]
-description = "Run cargo clippy."
+description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."
 clear = true
+run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = true }]
+
+[tasks.clippy-x64]
+description = "Run cargo clippy for x86_64-unknown-uefi."
+private = true
 command = "cargo"
-args = ["clippy", "--", "-D", "warnings"]
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64]
+description = "Run cargo clippy for aarch64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-std]
+description = "Run cargo clippy for std."
+private = true
+command = "cargo"
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 
 [tasks.fmt]
 description = "Run cargo format."

--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 # Base features included in all platform firmware builds.

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -68,34 +68,28 @@ clear = true
 command = "cargo"
 args = ["build", "--target", "aarch64-unknown-uefi", "@@split(BUILD_FLAGS, )", "@@split(UEFI_CRATES, )"]
 
-[tasks.check_json]
-description = "Checks rust code for errors with results in JSON. Example `cargo make check_json`"
-clear = true
-command = "cargo"
-args = ["check", "--message-format=json"]
-
-[tasks.check_no_std]
-description = "Checks rust code for no_std build errors with results."
+[tasks.check_code_x64]
+description = "Checks rust code for x64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--target", "x86_64-unknown-uefi", "@@split(NO_STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
-[tasks.check_std]
-description = "Checks rust code for std build errors with results."
+[tasks.check_code_aarch64]
+description = "Checks rust code for aarch64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "@@split(STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_tests]
 description = "Checks rust test code for build errors with results."
 private = true
 command = "cargo"
-args = ["test", "--no-run", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )",]
 
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
-run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
+run_task = [{ name = ["check_code_x64", "check_code_aarch64", "check_tests"], parallel = true }]
 
 [tasks.check-no-default-features-code]
 description = "Checks rust code compiles without default features."
@@ -207,10 +201,27 @@ exec --fail-on-error cargo test --target ${target} --workspace --features std
 '''
 
 [tasks.clippy]
-description = "Run cargo clippy."
+description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."
 clear = true
+run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = true }]
+
+[tasks.clippy-x64]
+description = "Run cargo clippy for x86_64-unknown-uefi."
+private = true
 command = "cargo"
-args = ["clippy", "--all-targets", "--", "-D", "warnings"]
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64]
+description = "Run cargo clippy for aarch64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-std]
+description = "Run cargo clippy for std."
+private = true
+command = "cargo"
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 
 [tasks.doc]
 env = { RUSTDOCFLAGS = "-D warnings"}

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
 UEFI_CRATES = "-p patina_mtrr"
 BUILD_CRATES = "-p patina_mtrr"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --timings"
 UEFI_CRATES = "-p patina_mtrr"
 BUILD_CRATES = "-p patina_mtrr"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --timings"
 UEFI_CRATES = "-p patina_paging"
 BUILD_CRATES = "-p patina_paging"
 COV_FLAGS = { value = "--profile test --ignore-filename-regex **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
 UEFI_CRATES = "-p patina_paging"
 BUILD_CRATES = "-p patina_paging"
 COV_FLAGS = { value = "--profile test --ignore-filename-regex **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -43,34 +43,28 @@ clear = true
 command = "cargo"
 args = ["build", "--target", "aarch64-unknown-uefi", "@@split(BUILD_FLAGS, )", "@@split(UEFI_CRATES, )"]
 
-[tasks.check_json]
-description = "Checks rust code for errors with results in JSON. Example `cargo make check_json`"
-clear = true
-command = "cargo"
-args = ["check", "--message-format=json"]
-
-[tasks.check_no_std]
-description = "Checks rust code for no_std build errors with results."
+[tasks.check_code_x64]
+description = "Checks rust code for x64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--target", "x86_64-unknown-uefi", "@@split(NO_STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
-[tasks.check_std]
-description = "Checks rust code for std build errors with results."
+[tasks.check_code_aarch64]
+description = "Checks rust code for aarch64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "@@split(STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_tests]
 description = "Checks rust test code for build errors with results."
 private = true
 command = "cargo"
-args = ["test", "--no-run", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )",]
 
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
-run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
+run_task = [{ name = ["check_code_x64", "check_code_aarch64", "check_tests"], parallel = true }]
 
 [tasks.check-no-default-features-code]
 description = "Checks rust code compiles without default features."
@@ -182,8 +176,25 @@ exec --fail-on-error cargo test --target ${target} --workspace
 '''
 
 [tasks.clippy]
-description = "Run cargo clippy."
+description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."
 clear = true
+run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = true }]
+
+[tasks.clippy-x64]
+description = "Run cargo clippy for x86_64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64]
+description = "Run cargo clippy for aarch64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-std]
+description = "Run cargo clippy for std."
+private = true
 command = "cargo"
 args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -16,7 +16,7 @@ X86_64_STD_LINUX_TARGET = "--target x86_64-unknown-linux-gnu"
 AARCH64_UEFI_TARGET = "--target aarch64-unknown-uefi"
 X86_64_UEFI_TARGET = "--target x86_64-unknown-uefi"
 
-NO_STD_FLAGS = "-Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem"
+NO_STD_FLAGS = "--timings"
 DXE_READINESS_PKG = "-p dxe_readiness_capture"
 CAPTURE_BIN_FLAGS = "${NO_STD_FLAGS} ${DXE_READINESS_PKG}"
 CAPTURE_UEFI_SHELL_FLAGS = "${DXE_READINESS_PKG} --features uefishell --bin uefishell_dxe_readiness_capture"

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -205,10 +205,50 @@ exec --fail-on-error cargo test --target ${target} --workspace
 '''
 
 [tasks.clippy]
-description = "Run cargo clippy."
+description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."
 clear = true
+run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = true }]
+
+[tasks.clippy-x64]
+description = "Run cargo clippy for x86_64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64]
+description = "Run cargo clippy for aarch64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-std]
+description = "Run cargo clippy for std."
+private = true
 command = "cargo"
 args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+
+[tasks.check_code_x64]
+description = "Checks rust code for x64 build errors with results."
+private = true
+command = "cargo"
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
+
+[tasks.check_code_aarch64]
+description = "Checks rust code for aarch64 build errors with results."
+private = true
+command = "cargo"
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
+
+[tasks.check_tests]
+description = "Checks rust test code for build errors with results."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )",]
+
+[tasks.check]
+description = "Checks rust code for errors. Example `cargo make check`"
+clear = true
+run_task = [{ name = ["check_code_x64", "check_code_aarch64", "check_tests"], parallel = true }]
 
 [tasks.doc]
 env = { RUSTDOCFLAGS = "-D warnings" }
@@ -235,7 +275,7 @@ command = "cargo"
 args = ["test", "--doc"]
 
 [tasks.cspell]
-description = "Run cspell for spell checking."                                                                                                                                     # npm install -g cspell@latest
+description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**,.azurepipelines/**,dxe_readiness_validator/src/tests/data/*.json}\" ."
 
 [tasks.deny]

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -16,7 +16,7 @@ X86_64_STD_LINUX_TARGET = "--target x86_64-unknown-linux-gnu"
 AARCH64_UEFI_TARGET = "--target aarch64-unknown-uefi"
 X86_64_UEFI_TARGET = "--target x86_64-unknown-uefi"
 
-NO_STD_FLAGS = "-Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options"
+NO_STD_FLAGS = "-Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem"
 DXE_READINESS_PKG = "-p dxe_readiness_capture"
 CAPTURE_BIN_FLAGS = "${NO_STD_FLAGS} ${DXE_READINESS_PKG}"
 CAPTURE_UEFI_SHELL_FLAGS = "${DXE_READINESS_PKG} --features uefishell --bin uefishell_dxe_readiness_capture"

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} --timings"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -113,11 +113,17 @@ clear = true
 command = "cargo"
 args = ["build", "@@split(STD_FLAGS, )", "--example", "dxe_core_std"]
 
-[tasks.check_code]
-description = "Checks rust code for no_std build errors with results."
+[tasks.check_code_x64]
+description = "Checks rust code for x64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
+
+[tasks.check_code_aarch64]
+description = "Checks rust code for aarch64 build errors with results."
+private = true
+command = "cargo"
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_tests]
 description = "Checks rust test code for build errors with results."
@@ -145,7 +151,7 @@ run_task = [{ name = ["check-no-default-features-code", "check-no-default-featur
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
-run_task = [{ name = ["check_code", "check_tests"], parallel = true }]
+run_task = [{ name = ["check_code_x64", "check_code_aarch64", "check_tests"], parallel = true }]
 
 [tasks.patina-test]
 description = "Builds crates with Patina tests enabled. Example `cargo make patina-test`"
@@ -278,8 +284,25 @@ command = "cargo"
 args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
 
 [tasks.clippy]
-description = "Run cargo clippy."
+description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."
 clear = true
+run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = true }]
+
+[tasks.clippy-x64]
+description = "Run cargo clippy for x86_64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64]
+description = "Run cargo clippy for aarch64-unknown-uefi."
+private = true
+command = "cargo"
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-std]
+description = "Run cargo clippy for std."
+private = true
 command = "cargo"
 args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -8,7 +8,7 @@
 default_to_workspace = false
 
 [env]
-NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings"
+NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"


### PR DESCRIPTION
Makefiles/CI: Update Clippy/Check Configuration
--
This updates makefiles for all repos and the CI to run clippy/check uniformly across the UEFI targets, as --all-targets does not do so (it builds bin, lib, etc.), and std/tests.

Makefiles: Drop Unstable Options Flag
--
-Zunstable-options was added to support --timings=json, but that was removed some time ago. As a result, unstable compiler options are no longer being passed, so remove the flag.

Makefiles: Drop -Zbuild-std and -Zbuild-std-features
--
These unstable compiler options are no longer needed for building Patina.

They can be used when a target is unsupported for building Rust std crates (including no_std alloc, core, etc.). The UEFI targets are supported, so this isn't needed.

They can also be used for applying custom profile settings to the core libraries. However, the two settings we primarily care about for Patina are binary size and debugging symbols in debug builds. A sample Patina DXE Core binary was 100KB smaller when not including these flags and still had all the debugging symbols (stepping through core libs in a debugger worked).

The other benefit is that build times are improved, for a sample Patina DXE Core binary build the time decreased from 39 seconds to 25 seconds.