### PR TITLE
.sync/Makefile-patina.toml: Clean mdbook deps on build

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -301,6 +301,19 @@ clear = true
 command = "cargo"
 args = ["test", "--doc"]
 
+[tasks.clean-mdbook-deps]
+description = """Removes the `target/mdbook/` directory to clean up old rlibs."""
+clear = true
+script_runner = "@duckscript"
+script = '''
+mdbook_target = set "target/mdbook"
+exists = is_path_exists ${mdbook_target}
+if ${exists}
+    echo Removing stale ${mdbook_target} directory...
+    rm -r ${mdbook_target}
+end
+'''
+
 [tasks.build-mdbook-deps]
 description = """Builds workspace libraries with the `mdbook` profile.
 This is a prerequisite for `cargo make test-mdbook`."""
@@ -308,7 +321,7 @@ clear = true
 env = { RUSTC_PROFILE = "mdbook" }
 command = "cargo"
 args = ["build", "--all-features", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(STD_FLAGS, )"]
-dependencies = ["individual-package-targets"]
+dependencies = ["clean-mdbook-deps", "individual-package-targets"]
 
 [tasks.test-mdbook]
 description = """Builds the mdbook and runs all of its embedded doctests with


### PR DESCRIPTION
To prevent multiple rlib candidates during mdbook build, this will remove the `target/mdbook` directory before building mdbook.

---

Prevents:

```
error[E0464]: multiple candidates for `rlib` dependency `patina` found
   --> dxe_core/memory_management.md:250:1
    |
250 | extern crate patina;
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: candidate #1: C:\src\patina\target/mdbook/deps\libpatina-0578c10102f67b3a.rlib
    = note: candidate #2: C:\src\patina\target/mdbook/deps\libpatina-1d28a091ef1e188b.rlib
```