### PR TITLE
Update nightly toolchain to 2026-02-27 (1.95.0)

### DIFF
--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2026-02-13" # One day post 1.93.1
+channel = "nightly-2026-02-27" # Nightly with the shared merge base to the 1.95.0 stable tag
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
The previous nightly toolchain was from 2026-02-13, which had partial support for some of the changes that ended up in Rust 1.95.0. This updates the toolchain to the same day the 1.95.0 stable tag was created.

Also fixes clippy issues reported after the update.