### PR TITLE
Makefile updates [Rebase & FF}

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -497,10 +497,10 @@ command = "cargo"
 args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-std]
-description = "Run cargo clippy for std."
+description = "Run cargo clippy for the host target (library and tests only)."
 private = true
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+args = ["clippy", "--tests", "--", "-D", "warnings"]
 
 [tasks.fmt]
 description = "Run cargo format."

--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -48,13 +48,13 @@ release ${joined_args}
 description = "Checks rust code for x64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
+args = ["check", "--target", "x86_64-unknown-uefi", "--features", "ci_features,x64", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_code_aarch64]
 description = "Checks rust code for aarch64 build errors with results."
 private = true
 command = "cargo"
-args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
+args = ["check", "--target", "aarch64-unknown-uefi", "--features", "ci_features,aarch64", "@@split(CARGO_MAKE_TASK_ARGS, )", "@@split(NO_STD_FLAGS, )",]
 
 [tasks.check_tests]
 description = "Checks rust test code for build errors with results."
@@ -488,13 +488,13 @@ run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = 
 description = "Run cargo clippy for x86_64-unknown-uefi."
 private = true
 command = "cargo"
-args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features,x64", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-aarch64]
 description = "Run cargo clippy for aarch64-unknown-uefi."
 private = true
 command = "cargo"
-args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features,aarch64", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-std]
 description = "Run cargo clippy for the host target (library and tests only)."

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -212,14 +212,36 @@ run_task = [{ name = ["clippy-x64", "clippy-aarch64", "clippy-std"], parallel = 
 [tasks.clippy-x64]
 description = "Run cargo clippy for x86_64-unknown-uefi."
 private = true
+run_task = [{ name = ["clippy-x64-core", "clippy-x64-uefishell"] }]
+
+[tasks.clippy-x64-core]
+description = "Run cargo clippy for x86_64-unknown-uefi core binaries."
+private = true
 command = "cargo"
-args = ["clippy", "--target", "x86_64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+args = ["clippy", "@@split(DXE_READINESS_PKG, )", "--target", "x86_64-unknown-uefi", "--lib", "--bin", "intel_dxe_readiness_capture", "--bin", "qemu_dxe_readiness_capture", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-x64-uefishell]
+description = "Run cargo clippy for x86_64-unknown-uefi uefishell binary."
+private = true
+command = "cargo"
+args = ["clippy", "@@split(DXE_READINESS_PKG, )", "--target", "x86_64-unknown-uefi", "--features", "uefishell", "--bin", "uefishell_dxe_readiness_capture", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-aarch64]
 description = "Run cargo clippy for aarch64-unknown-uefi."
 private = true
+run_task = [{ name = ["clippy-aarch64-core", "clippy-aarch64-uefishell"] }]
+
+[tasks.clippy-aarch64-core]
+description = "Run cargo clippy for aarch64-unknown-uefi core binaries."
+private = true
 command = "cargo"
-args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+args = ["clippy", "@@split(DXE_READINESS_PKG, )", "--target", "aarch64-unknown-uefi", "--lib", "--bin", "qemu_dxe_readiness_capture", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
+
+[tasks.clippy-aarch64-uefishell]
+description = "Run cargo clippy for aarch64-unknown-uefi uefishell binary."
+private = true
+command = "cargo"
+args = ["clippy", "@@split(DXE_READINESS_PKG, )", "--target", "aarch64-unknown-uefi", "--features", "uefishell", "--bin", "uefishell_dxe_readiness_capture", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-std]
 description = "Run cargo clippy for the host target (library and tests only)."

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -222,10 +222,10 @@ command = "cargo"
 args = ["clippy", "--target", "aarch64-unknown-uefi", "--features", "ci_features", "@@split(NO_STD_FLAGS, )", "--", "-D", "warnings"]
 
 [tasks.clippy-std]
-description = "Run cargo clippy for std."
+description = "Run cargo clippy for the host target (library and tests only)."
 private = true
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+args = ["clippy", "--tests", "--", "-D", "warnings"]
 
 [tasks.check_code_x64]
 description = "Checks rust code for x64 build errors with results."


### PR DESCRIPTION
A few commits to update makefiles that are synced.

---

**Only run clippy-std on tests in UEFI bin repos**

The synced clippy-std task ran `cargo clippy --all-targets
--all-features` on the host target. With `--all-features` enabled,
the bins' `required-features` are satisfied and cargo tries to
compile them on the host.

Each bin starts with `#![cfg(all(target_os = "uefi", feature = "x64"))]` plus
`#![no_main]`, so on a non-uefi target the entire file (including
`#![no_main]`) is stripped, resulting in E0601.

This change narrow the task to `cargo clippy --tests -- -D warnings`,
which pulls in the lib via the test build and leaves the bins out.

---

**patina-dxe-core-qemu Makefile: Fix Clippy/Check Args**

This updates the makefile to specify x64 and aarch64 in
addition to the ci_features for the given arch.

---

**patina-readiness-tool Makefile: Split Core and UefiShell Clippy/Check**

The current combined configuration does not work to build the
binaries intended to be core replacements with the uefi shell
version. The uefishell feature requires certain things because
it uses the uefi crate.

As such, this splits the clippy and check targets like the build
targets are.