### PR TITLE
.sync: Group cargo dependencies in dependabot.yml

### DIFF
--- a/.sync/dependabot/dependabot.yml
+++ b/.sync/dependabot/dependabot.yml
@@ -29,6 +29,13 @@ updates:
     labels:
       - "type:dependencies"
       - "type:dependabot"
+    groups:
+      all-cargo-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Group dependencies so they are updated in a single pull request.

---

Note: This does not include `major` version updates since they will often require integration changes.

---

Test PR created from changes on fork: https://github.com/makubacki/patina-readiness-tool/pull/3