### PR TITLE
.sync: Add armvirt tasks to patina-dxe-core-qemu Makefile.toml

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -469,6 +469,16 @@ description = """Builds the RELEASE OVMF UEFI firmware."""
 env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
+[tasks.armvirt]
+description = """Builds the DEBUG VIRT UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_armvirt_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_armvirt_dxe_core.pdb" }
+run_task = "patch"
+
+[tasks.armvirt-release]
+description = """Builds the RELEASE VIRT UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_armvirt_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_armvirt_dxe_core.pdb" }
+run_task = "patch"
+
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"


### PR DESCRIPTION
The new `armvirt` tasks are used to build the armvirt binaries.

These changes are already checked into patina-dxe-core-qemu/main.