### PR TITLE
Update to 1.96.0-nightly

### DIFF
--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2026-02-27" # Nightly with the shared merge base to the 1.95.0 stable tag
+channel = "nightly-2026-04-11" # Last nightly build of 1.96.0-nightly
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
This updates all repos to 1.96.0-nightly as there was a bug in Rust 1.95.0-nightly that prevented rust-analyzer from running fully. There were no changes required in Patina to use the newer version.

Tested locally with `cargo make all`, also testing full CI via this PR: https://github.com/OpenDevicePartnership/patina/pull/1549.

Associated rust-analyzer issue (there are a few others): https://github.com/rust-lang/rust-analyzer/issues/21715.