### PR TITLE
.sync: Use the first channel for mdbook test task

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -357,13 +357,18 @@ script_runner = "@duckscript"
 script = '''
 toolchain_file = readfile rust-toolchain.toml
 channel = set "stable"
+found = set false
 lines = split ${toolchain_file} "\n"
 for line in ${lines}
     trimmed = trim ${line}
     starts = starts_with ${trimmed} "channel"
+    # Only use the first `channel` line (the one under `[toolchain]`).
     if ${starts}
-        parts = split ${trimmed} "\""
-        channel = array_get ${parts} 1
+        if not ${found}
+            parts = split ${trimmed} "\""
+            channel = array_get ${parts} 1
+            found = set true
+        end
     end
 end
 exec --fail-on-error mdbook build docs


### PR DESCRIPTION
Similar to the change made in fcb9652, update the `test-mdbook` task for the `[msrv]` section. Due to the way duckscript works, this is implemented to use the first channel found in the file for simplicity which will be true for how we maintain the file.