### PR TITLE
Switch to do ARM virt for pipeline validation

### DIFF
--- a/.github/actions/run-patina-qemu-validation/action.yml
+++ b/.github/actions/run-patina-qemu-validation/action.yml
@@ -28,7 +28,7 @@ inputs:
     description: Absolute path to the patina-qemu repository containing build_and_run_rust_binary.py.
     required: true
   platform:
-    description: QEMU platform name (e.g. Q35 or SBSA).
+    description: QEMU platform name (e.g. Q35 or ArmVirt).
     required: true
   pre-compiled-rom:
     description: Absolute path to the pre-compiled firmware ROM file.

--- a/.github/actions/run-patina-qemu-validation/run_qemu_validation.py
+++ b/.github/actions/run-patina-qemu-validation/run_qemu_validation.py
@@ -26,7 +26,7 @@ JSON keys:
   patina_qemu_repo    (string, required)  Path to the patina-qemu repository
                       containing build_and_run_rust_binary.py.
   platform            (string, required)  QEMU platform name (e.g. "Q35" or
-                      "SBSA").
+                      "ArmVirt").
   pre_compiled_rom    (string, required)  Path to the pre-compiled firmware ROM
                       file.
   qemu_path           (string, optional)  Path to the QEMU executable. Only

--- a/.github/actions/setup-patina-qemu-validation/action.yml
+++ b/.github/actions/setup-patina-qemu-validation/action.yml
@@ -124,5 +124,5 @@ runs:
           run_cmd cargo make q35 -- --exclude-features exit_on_patina_test_failure
         fi
         run_cmd cargo make q35-release -- --exclude-features exit_on_patina_test_failure
-        run_cmd cargo make sbsa -- --exclude-features exit_on_patina_test_failure
-        run_cmd cargo make sbsa-release -- --exclude-features exit_on_patina_test_failure
+        run_cmd cargo make armvirt -- --exclude-features exit_on_patina_test_failure
+        run_cmd cargo make armvirt-release -- --exclude-features exit_on_patina_test_failure

--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -150,7 +150,7 @@ jobs:
       patina_qemu_sha: ${{ steps.dep-shas.outputs.patina_qemu_sha }}
       patina_sha: ${{ steps.dep-shas.outputs.patina_sha }}
       q35_fw_url: ${{ steps.fw-assets.outputs.q35_url }}
-      sbsa_fw_url: ${{ steps.fw-assets.outputs.sbsa_url }}
+      armvirt_fw_url: ${{ steps.fw-assets.outputs.armvirt_url }}
     steps:
       - name: Validate Inputs
         shell: bash
@@ -258,18 +258,18 @@ jobs:
           assets = {a['name'] for a in release.get('assets', [])}
 
           q35_name = f'patina-qemu-q35-{tag}.zip'
-          sbsa_name = f'patina-qemu-sbsa-{tag}.zip'
+          armvirt_name = f'patina-qemu-armvirt-{tag}.zip'
 
           output_file = pathlib.Path(os.environ['GITHUB_OUTPUT'])
           with output_file.open('a', encoding='utf-8') as out:
               out.write(f'patina_qemu_fw_tag={tag}\n')
 
-          if q35_name in assets and sbsa_name in assets:
+          if q35_name in assets and armvirt_name in assets:
               print(f'All expected firmware assets present for {tag}')
               with output_file.open('a', encoding='utf-8') as out:
                   out.write('assets_complete=true\n')
           else:
-              missing = [n for n in (q35_name, sbsa_name) if n not in assets]
+              missing = [n for n in (q35_name, armvirt_name) if n not in assets]
               print(f'::warning::Missing firmware assets in patina-qemu {tag} release: {", ".join(missing)}')
               print('Cache will not be saved - firmware zip files may still be uploading')
               with output_file.open('a', encoding='utf-8') as out:
@@ -420,19 +420,19 @@ jobs:
 
           tag = release['tag_name']
           q35_name = f'patina-qemu-q35-{tag}.zip'
-          sbsa_name = f'patina-qemu-sbsa-{tag}.zip'
+          armvirt_name = f'patina-qemu-armvirt-{tag}.zip'
 
           assets = {asset['name']: asset['browser_download_url'] for asset in release.get('assets', [])}
           if q35_name not in assets:
               raise SystemExit(f'Missing expected Q35 firmware asset: {q35_name}')
-          if sbsa_name not in assets:
-              raise SystemExit(f'Missing expected SBSA firmware asset: {sbsa_name}')
+          if armvirt_name not in assets:
+              raise SystemExit(f'Missing expected ArmVirt firmware asset: {armvirt_name}')
 
           output_file = pathlib.Path(os.environ['GITHUB_OUTPUT'])
           with output_file.open('a', encoding='utf-8') as out:
               out.write(f'tag={tag}\n')
               out.write(f'q35_url={assets[q35_name]}\n')
-              out.write(f'sbsa_url={assets[sbsa_name]}\n')
+              out.write(f'armvirt_url={assets[armvirt_name]}\n')
           PY
 
   validate-qemu-linux:
@@ -481,11 +481,11 @@ jobs:
             fw_cache_key_suffix: q35
             rom_subpath: Q35/DEBUG Linux/QEMUQ35_CODE.fd
             log_file: q35-linux.log
-          - platform: SBSA
-            fw_zip: sbsa.zip
-            fw_cache_key_suffix: sbsa
-            rom_subpath: SBSA/DEBUG Linux/QEMU_EFI.fd
-            log_file: sbsa-linux.log
+          - platform: ArmVirt
+            fw_zip: armvirt.zip
+            fw_cache_key_suffix: armvirt
+            rom_subpath: ArmVirt/DEBUG Linux/QEMU_EFI.fd
+            log_file: armvirt-linux.log
 
     steps:
       - name: Checkout Repository
@@ -544,7 +544,7 @@ jobs:
         if: steps.firmware-cache.outputs.cache-hit != 'true'
         shell: bash
         env:
-          FW_URL: ${{ matrix.platform == 'Q35' && needs.preflight.outputs.q35_fw_url || needs.preflight.outputs.sbsa_fw_url }}
+          FW_URL: ${{ matrix.platform == 'Q35' && needs.preflight.outputs.q35_fw_url || needs.preflight.outputs.armvirt_fw_url }}
         run: |
           mkdir -p .cache/patina-qemu
           curl -L "$FW_URL" -o .cache/patina-qemu/${{ matrix.fw_zip }}
@@ -627,7 +627,7 @@ jobs:
         with:
           path: |
             .cache/patina-qemu/q35.zip
-            .cache/patina-qemu/sbsa.zip
+            .cache/patina-qemu/armvirt.zip
           key: patina-qemu-fw-${{ runner.os }}-${{ needs.preflight.outputs.fw_release_tag }}
 
       - name: Download patina-qemu FW Binaries
@@ -636,13 +636,13 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path .cache\patina-qemu -Force | Out-Null
           Invoke-WebRequest -Uri "${{ needs.preflight.outputs.q35_fw_url }}" -OutFile ".cache\patina-qemu\q35.zip"
-          Invoke-WebRequest -Uri "${{ needs.preflight.outputs.sbsa_fw_url }}" -OutFile ".cache\patina-qemu\sbsa.zip"
+          Invoke-WebRequest -Uri "${{ needs.preflight.outputs.armvirt_fw_url }}" -OutFile ".cache\patina-qemu\armvirt.zip"
 
       - name: Extract patina-qemu FW Binaries
         shell: pwsh
         run: |
           Expand-Archive -Path .cache\patina-qemu\q35.zip -DestinationPath "$env:FW_DIR" -Force
-          Expand-Archive -Path .cache\patina-qemu\sbsa.zip -DestinationPath "$env:FW_DIR" -Force
+          Expand-Archive -Path .cache\patina-qemu\armvirt.zip -DestinationPath "$env:FW_DIR" -Force
 
       - name: Setup and Build patina-dxe-core-qemu
         uses: OpenDevicePartnership/patina-devops/.github/actions/setup-patina-qemu-validation@main

--- a/.github/workflows/PatinaQemuPrValidationPost.yml
+++ b/.github/workflows/PatinaQemuPrValidationPost.yml
@@ -352,7 +352,7 @@ jobs:
               if (!osMatch) return '';
               const os = osMatch[1]; // "Linux" or "Windows"
 
-              // Try to extract the platform from the job name (e.g. "Q35", "SBSA")
+              // Try to extract the platform from the job name (e.g. "Q35", "ArmVirt")
               const platMatch = jobName.match(/Validate QEMU\s*[-–—]?\s*(\w+)\s*\(/);
               const platform = platMatch ? platMatch[1] : null;
 


### PR DESCRIPTION
This change switches to newly onboarded ARM virt platform for PR validation.

The SBSA call out will be dropped after this change.

Needs to be merged after https://github.com/OpenDevicePartnership/patina-qemu/pull/250.