### PR TITLE
.sync: deny.toml Updates [Rebase & FF]

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -184,8 +184,6 @@ group:
     repos: |
       OpenDevicePartnership/patina
       OpenDevicePartnership/patina-dxe-core-qemu
-      OpenDevicePartnership/patina-mtrr
-      OpenDevicePartnership/patina-paging
 
   - files:
     - source: .sync/rust/deny.toml

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -175,6 +175,7 @@ group:
           - '{ crate = "tiny-keccak", reason = "Not updated in 5 years. Use alternative." }'
         ignored_rust_security_advisories:
           # Example: '{ id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." }'
+           - '{ id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" }'
         license_exceptions:
           - '{ allow = ["0BSD"], crate = "managed" }'
           - '{ allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib" }'


### PR DESCRIPTION
**.sync/Files.yml: Drop deny.toml sync to patina-mtrr and patina-paging repos**

By design, these repos have a very minimal set of dependencies that
are not shared with the main patina repo and other Patina crates.

This change removes deny.toml being synced to those repos since they
will likely have minimal deny.toml changes over time and can simply
be maintained independently and locally in those repos.

---

**.sync: Add paste to ignore sec advisory list in deny.toml**

The `paste` crate is marked as unmaintained in the RustSec advisory
database and pulled in transitively with `arm-gic` -> `arm-sysregs`:

```
   ├ paste v1.0.15
     └── arm-sysregs v0.2.9
         └── arm-gic v0.8.1
             ├── patina_dxe_core v22.0.1
             │   └── qemu_dxe_core v3.0.8
             └── patina_internal_cpu v22.0.1
                 ├── patina_debugger v22.0.1
                 │   ├── patina_dxe_core v22.0.1 (*)
                 │   └── qemu_dxe_core v3.0.8 (*)
                 └── patina_dxe_core v22.0.1 (*)
```

This applies to the patina and patina-dxe-core-qemu repos. For now,
an exception is added to the deny.toml file to ignore this advisory
since it is only a build-time dependency and unmaintained.

```
error[unmaintained]: paste - no longer maintained
   ┌─ patina-dxe-core-qemu/Cargo.lock:37:1
   │
37 │ paste 1.0.15 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0436
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
   ├ The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md)
     that this project is not longer maintained as well as archived the repository
```