### PR TITLE
Use a consistent markdownlint file name

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Markdown Linting
         uses: avto-dev/markdown-lint@v1.5.0
         with:
-          config: .markdownlint.yml
+          config: .markdownlint.yaml
           args: "**/*.md"
 
       # Run the tests that require the rust tools, but not a specific OS.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,4 @@
-# @file .markdownlint.yml
+# @file .markdownlint.yaml
 #
 # Patina markdownlint configuration file
 #

--- a/.sync/markdownlint/.markdownlint.yaml
+++ b/.sync/markdownlint/.markdownlint.yaml
@@ -1,4 +1,4 @@
-# @file .markdownlint.yml
+# @file .markdownlint.yaml
 #
 # Patina markdownlint configuration file
 #


### PR DESCRIPTION
The file is actually named `.markdownlint.yaml` right now. Several places refer to it as `.markdownlint.yml`. One is CiWorkflow.yml, which results in the config not being read in the workflow:

```
Cannot read or parse config file .markdownlint.yml:
  ENOENT: no such file or directory, open '.markdownlint.yml'
```

Renaming the file would be more impactful to repo contents so this just makes the name consistent in the workflow and other files.