### PR TITLE
.github: Use GitHub token on pull_request events

### DIFF
--- a/.github/workflows/MsrvCheck.yml
+++ b/.github/workflows/MsrvCheck.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
@@ -58,7 +59,8 @@ jobs:
       - name: ✅ Checkout Repository ✅
         uses: actions/checkout@v7
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          # Falls back to the default GITHUB_TOKEN when the app token step was skipped (PR runs).
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       # Parse [msrv].channel from rust-toolchain.toml and rust-version from
       # the workspace Cargo.toml.


### PR DESCRIPTION
The workflow only needs the app token on scheduled runs to create and manage GitHub issues. Since issues are not created or used when the workflow is triggered by a `pull_request` event, it is skipped to drop the need for the secret.

---

Tested workflow with a pull request from a fork - it succeeds with token generation from the secret skipped.

<img width="386" height="685" alt="image" src="https://github.com/user-attachments/assets/957cecc7-1518-4ae4-aaf8-69148481d388" />