### PR TITLE
Switch to the stable toolchain (and RUSTC_BOOTSTRAP=1)

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -353,6 +353,7 @@ doctests link against rlibs built by the same compiler, and points `mdbook test`
 to the mdbook profile `target/mdbook/deps/` directory produced by `build-mdbook-deps`.
 """
 clear = true
+env = { RUSTC_BOOTSTRAP = "1" }
 script_runner = "@duckscript"
 script = '''
 toolchain_file = readfile rust-toolchain.toml

--- a/.sync/rust/config.toml
+++ b/.sync/rust/config.toml
@@ -6,6 +6,15 @@
 
 [env]
 PATINA_CONFIG_VERSION = "1"
+RUSTC_BOOTSTRAP = "1"
+
+# Restrict the unstable features RUSTC_BOOTSTRAP makes available to only those Patina has accepted
+# through the unstable feature process. This applies to host builds (tests, proc-macros).
+# The UEFI targets below repeat the flag because Cargo does not merge rustflags sources.
+[build]
+rustflags = [
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+]
 
 [profile.dev]
 # optimize for size
@@ -61,6 +70,8 @@ rustflags = [
     "-C", "force-frame-pointers",
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
+    # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -71,4 +82,6 @@ rustflags = [
     "-C", "force-frame-pointers",
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
+    # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
 ]

--- a/.sync/rust/rust-toolchain.toml
+++ b/.sync/rust/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2026-04-11" # Last nightly build of 1.96.0-nightly
+channel = "1.95.0"
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"{% for target in additional_targets %}, "{{ target }}"{% endfor %}]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
@@ -23,4 +23,4 @@ mdbook-linkcheck = "0.7.7"
 mdbook-mermaid = "0.16.2"
 
 [msrv]
-channel = "nightly-2025-06-20"   # branched-from date for rust-version = "1.89"
+channel = "1.89.0"


### PR DESCRIPTION
Per RFC 0030, switch to the stable toolchain and set RUSTC_BOOTSTRAP=1 to allow the stable toolchain to accept the unstable feature gates Patina still depends on.

Sets `allow-features` to the list of unstable features Patina uses.

---

Tested `cargo make all` in various repos with these file changes.