### PR TITLE
.sync: Add `install-tools` task to Makefile.toml files

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-dxe-core-qemu.toml
@@ -22,6 +22,87 @@ RUSTC_PROFILE = "dev"
 [env.release]
 RUSTC_PROFILE = "release"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 [tasks.individual-package-targets]
 script_runner = "@duckscript"
 script = '''

--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -21,6 +21,87 @@ RUSTC_TARGET = "debug"
 RUSTC_PROFILE = "release"
 RUSTC_TARGET = "release"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 [tasks.build]
 description = """Builds a single rust package with the standard library.
 

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -21,6 +21,87 @@ RUSTC_TARGET = "debug"
 RUSTC_PROFILE = "release"
 RUSTC_TARGET = "release"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 [tasks.build-x64]
 description = """Builds patina_paging crate as UEFI target.
 

--- a/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-readiness-tool.toml
@@ -21,6 +21,87 @@ DXE_READINESS_PKG = "-p dxe_readiness_capture"
 CAPTURE_BIN_FLAGS = "${NO_STD_FLAGS} ${DXE_READINESS_PKG}"
 CAPTURE_UEFI_SHELL_FLAGS = "${DXE_READINESS_PKG} --features uefishell --bin uefishell_dxe_readiness_capture"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 # DXE Readiness Capture UEFI binaries to run from UEFI Shell.
 [tasks.build-x64-uefishell]
 description = "Builds the DXE Readiness Capture UEFI binary to run in UEFI Shell."

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -19,6 +19,87 @@ RUSTC_PROFILE = "dev"
 [env.release]
 RUSTC_PROFILE = "release"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 [tasks.individual-package-targets]
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
Patina maintains a list of project tools in the `[tools]` section of `rust-toolchain.toml`. While CI directly installs these tools, local developers have to do so manually. That was raised as a pain point as noted in the referenced GitHub issue.

This commit adds a new `install-tools` task to the Makefile that will automatically install all tools listed in the `[tools]` section of `rust-toolchain.toml`. The task first verifies that `cargo-binstall` is installed, and if not, it installs it. Then it parses the `[tools]` section of `rust-toolchain.toml` and installs each tool using `cargo binstall`.

---

Notes:

- This task primarily targets the `patina` repo and the change was made directly there in https://github.com/OpenDevicePartnership/patina/pull/1615 for visibility. This syncs the change to all other repos.
- The `rust-tool-cache` GitHub action [performs a similar iteration](https://github.com/OpenDevicePartnership/patina-devops/blob/main/.github/actions/rust-tool-cache/action.yml#L52) over the tools and installs them with `cargo-binstall`. That is not updated to use this task (at least for now) because it installs `cargo-make` itself for the CI runner in the loop. It would be trivial after the `Install cargo-binstall` task to have a `Install cargo-make` task and then run `cargo make install-tools`. However, to install the correct version of `cargo-make` would require parsing `rust-toolchain.toml` which is redundant anyway.