### PR TITLE
.sync/Files.yml: Sync patina Makefile.toml to patina-components

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -233,6 +233,7 @@ group:
       dest: Makefile.toml
     repos: |
       OpenDevicePartnership/patina
+      OpenDevicePartnership/patina-components
 
 # Rust Configuration - Rust Toolchain
   - files:


### PR DESCRIPTION
Today, a Makefile.toml file is not synced to the patina-components repo. The Makefile.toml there is stale. Since that repo is expected to build a workspace of library crates (similar to patina), this commit syncs the patina Makefile.toml file there as well to reduce overall maintenance and to keep its cargo-make tasks in sync with the main patina repo.