### PR TITLE
.sync/Files.yml: Sync publish-mdbook.yml to patina-components

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -670,6 +670,7 @@ group:
       dest: .github/workflows/publish-mdbook.yml
     repos: |
       OpenDevicePartnership/patina
+      OpenDevicePartnership/patina-components
       OpenDevicePartnership/patina-qemu
 
 # Workflow - Publish Release


### PR DESCRIPTION
Sync the publish-mdbook.yml workflow to patina-components since it has a mdbook now.

- Note: mdbook added to patina-components in https://github.com/OpenDevicePartnership/patina-components/pull/26