### PR TITLE
Only allow `coverage_attribute` when running coverage

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -206,6 +206,11 @@ args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
+# `coverage_attribute` is deliberately excluded from the default allow-features in
+# .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
+# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# Note: RUSTFLAGS replaces build.rustflags.
+env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["llvm-cov-clean"]

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -181,6 +181,11 @@ args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
+# `coverage_attribute` is deliberately excluded from the default allow-features in
+# .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
+# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# Note: RUSTFLAGS replaces build.rustflags.
+env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["llvm-cov-clean"]

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -239,6 +239,11 @@ args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
+# `coverage_attribute` is deliberately excluded from the default allow-features in
+# .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
+# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# Note: RUSTFLAGS replaces build.rustflags.
+env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["individual-package-targets", "llvm-cov-clean"]

--- a/.sync/rust/config.toml
+++ b/.sync/rust/config.toml
@@ -18,9 +18,12 @@ RUSTC_BOOTSTRAP = "1"
 # they fail with E0725. If you must run `-Zbuild-std`, override rustflags for that invocation with
 # the RUSTFLAGS env var (which replaces these config rustflags), keeping everything else but dropping
 # `-Z allow-features`.
+#
+# Note: `coverage_attribute` is intentionally not in this list. It is only set in allow-features
+# when running coverage.
 [build]
 rustflags = [
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]
 
 [profile.dev]
@@ -78,7 +81,8 @@ rustflags = [
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
     # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    # (coverage_attribute excluded on purpose; coverage runs add it via RUSTFLAGS)
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -90,5 +94,6 @@ rustflags = [
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
     # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    # (coverage_attribute excluded on purpose; coverage runs add it via RUSTFLAGS)
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]


### PR DESCRIPTION
Supplements the change made to narrow the set of unstable features allowed in commit 599797b by only allowing `coverage_attribute` when running coverage.

Removes `coverage_attribute` from `allow-features` by default and only sets it when running coverage (`cargo make coverage`). This allows the feature where it is needed and catches any accidental usage of `#[coverage(off)]` where it is not gated on `cfg(coverage_nightly)`.

Updates all Makefile.toml files that contain a coverage task that use cargo-llvm-cov.