### PR TITLE
.sync: Use LF line endings for stderr files

### DIFF
--- a/.sync/git/gitattributes_template.txt
+++ b/.sync/git/gitattributes_template.txt
@@ -1,1 +1,2 @@
 * -text
+*.stderr text=auto eol=lf


### PR DESCRIPTION
This was already checked into Patina in:

https://github.com/OpenDevicePartnership/patina/commit/7af94302101212117cad9ec1614ba179b1488fe6

It is added to patina-devops here so it will be included in the file sync.