### PR TITLE
.github: Add temporary checkout workaround in PatinaQemuPrValidation

### DIFF
--- a/.github/workflows/PatinaQemuPrValidation.yml
+++ b/.github/workflows/PatinaQemuPrValidation.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          allow-unsafe-pr-checkout: true # Temporary. Tracked in https://github.com/OpenDevicePartnership/patina-devops/issues/166.
           repository: ${{ inputs.patina-ref != '' && 'OpenDevicePartnership/patina' || 'OpenDevicePartnership/patina-dxe-core-qemu' }}
           ref: ${{ inputs.patina-ref || inputs.dxe-core-qemu-ref }}
 
@@ -491,6 +492,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          allow-unsafe-pr-checkout: true # Temporary. Tracked in https://github.com/OpenDevicePartnership/patina-devops/issues/166.
           repository: ${{ inputs.patina-ref != '' && 'OpenDevicePartnership/patina' || 'OpenDevicePartnership/patina-dxe-core-qemu' }}
           ref: ${{ inputs.patina-ref || inputs.dxe-core-qemu-ref }}
 
@@ -603,6 +605,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          allow-unsafe-pr-checkout: true # Temporary. Tracked in https://github.com/OpenDevicePartnership/patina-devops/issues/166.
           repository: ${{ inputs.patina-ref != '' && 'OpenDevicePartnership/patina' || 'OpenDevicePartnership/patina-dxe-core-qemu' }}
           ref: ${{ inputs.patina-ref || inputs.dxe-core-qemu-ref }}
 


### PR DESCRIPTION
Checkout is blocked for v6 and v7. This change applies a workaround to allow the workflow to continue to run until the long-term solution to refactor the workflow is implemented.

---

This is due to a breaking change made in v6 yesterday: [v6.1.0](https://github.com/actions/checkout/releases/tag/v6.1.0)