### PR TITLE
.github: Install cargo tools with --locked

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -92,7 +92,7 @@ runs:
           echo ""
 
           # Attempt to binstall the tool first. If it fails, install it using cargo
-          cargo binstall -y $TOOL_NAME --version $TOOL_VERSION || cargo install $TOOL_NAME --version $TOOL_VERSION
+          cargo binstall -y $TOOL_NAME --version $TOOL_VERSION || cargo install $TOOL_NAME --version $TOOL_VERSION --locked
         done
       if: steps.tool-cache.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
As noted in the cargo-install documentation at:

https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile

> By default, the Cargo.lock file that is included with the package
> will be ignored. This means that Cargo will recompute which versions
> of dependencies to use, possibly using newer versions that have been
> released since the package was published. The --locked flag can be
> used to force Cargo to use the packaged Cargo.lock file if it is
> available.
>
> This may be useful for ensuring reproducible builds, to use the
> exact same set of dependencies that were available when the package
> was published. It may also be useful if a newer version of a
> dependency is published that no longer builds on your system, or
> has other problems. The downside to using --locked is that you will
> not receive any fixes or updates to any dependency.

Tool installation has started failing in CI recently because of the reasons noted above. In the current case, a crate is being picked up that requires Rust 1.96.0 while Patina is on 1.95.0.

This change adds the `--locked` flag to fix the current issue and prevent similar issues in the future.