### PR TITLE
.sync: Change coverage_nightly to coverage in makefiles

### DIFF
--- a/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-mtrr.toml
@@ -208,7 +208,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"

--- a/.sync/rust/Makefiles/Makefile-patina-paging.toml
+++ b/.sync/rust/Makefiles/Makefile-patina-paging.toml
@@ -183,7 +183,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"

--- a/.sync/rust/Makefiles/Makefile-patina.toml
+++ b/.sync/rust/Makefiles/Makefile-patina.toml
@@ -241,7 +241,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"


### PR DESCRIPTION
Each of these repos are switching from coverage_nightly to coverage.

This change updates the makefiles for each repo.