### PR TITLE
Bump Version.njk in Preparation for Release

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,4 +30,4 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set patina_devops = "v0.3.12" %}
+{% set patina_devops = "v0.3.13" %}


### PR DESCRIPTION
Version 3.13 is going to be released, so update
the version. This will contain, among other changes, an updated CI pipeline that contains a name change for the markdown lint configuration file, which is currently being missed in patina-devops consumers.