### PR TITLE
.github: Recognize `closed` and `unsupported_target_branch` skip reasons

### DIFF
--- a/.github/workflows/PatinaQemuPrValidationPost.yml
+++ b/.github/workflows/PatinaQemuPrValidationPost.yml
@@ -664,6 +664,12 @@ jobs:
             if (skipReason === 'merged') {
               title = ':information_source: QEMU Validation Skipped - PR Merged';
               message = 'The Patina QEMU PR validation workflow did not run because the PR was merged before validation started.';
+            } else if (skipReason === 'closed') {
+              title = ':information_source: QEMU Validation Skipped - PR Closed';
+              message = 'The Patina QEMU PR validation workflow did not run because the PR was closed before validation started.';
+            } else if (skipReason === 'unsupported_target_branch') {
+              title = ':information_source: QEMU Validation Skipped - Unsupported Target Branch';
+              message = 'The Patina QEMU PR validation workflow did not run because the PR targets an unsupported branch.';
             } else {
               title = ':information_source: QEMU Validation Skipped - PR Branch Unavailable';
               message = 'The Patina QEMU PR validation workflow did not run because the PR branch is no longer accessible.';


### PR DESCRIPTION
Adds support for additional skip reasons produced in:

https://github.com/OpenDevicePartnership/patina/blob/main/.github/workflows/patina-qemu-pr-validation.yml

This includes the following skip reasons:

- `closed`
- `unsupported_target_branch`

This simply makes the PR comment more informative when the workflow is skipped for these reasons.